### PR TITLE
Update CallGraph to use Nuanced formatter

### DIFF
--- a/src/nuanced/lib/call_graph.py
+++ b/src/nuanced/lib/call_graph.py
@@ -29,5 +29,5 @@ class CallGraph():
         self.call_graph.analyze()
 
     def to_dict(self) -> dict:
-        formatter = formats.Simple(self.call_graph)
+        formatter = formats.Nuanced(self.call_graph)
         return formatter.generate()

--- a/uv.lock
+++ b/uv.lock
@@ -47,8 +47,10 @@ wheels = [
 [[package]]
 name = "jarviscg"
 version = "0.1.0"
-source = { git = "https://github.com/nuanced-dev/jarviscg#030e696cf4ac514b842a10f2a793136d056674d0" }
+source = { git = "https://github.com/nuanced-dev/jarviscg.git#8456d8fff39a2c3e716a9bae27a7b9775f075be4" }
 dependencies = [
+    { name = "deepdiff" },
+    { name = "pytest" },
     { name = "setuptools", version = "75.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "setuptools", version = "75.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
@@ -72,7 +74,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "deepdiff", specifier = ">=8.2.0" },
     { name = "jarviscg", git = "https://github.com/nuanced-dev/jarviscg" },
     { name = "setuptools", specifier = ">=75.3.0" },
 ]


### PR DESCRIPTION
## Why?

https://github.com/nuanced-dev/jarviscg/pull/14 introduced a new call graph formatter, `jarviscg.formats.Nuanced`, which includes filepaths in the formatted call graph. This PR updates `CallGraph` to use the `Nuanced` formatter instead of the `Simple` formatter.

## How?

- Update uv.lock so nuanced-graph installs jarviscg from most recent git commit
- Update `CallGraph#to_dict` to use `jarviscg.formats.Nuanced`

## Testing

Here's a subgraph of the fake-id repo generated from nuanced-graph's `main` branch:

```json
{
"api.routes.deckard.authenticated": [
    "api.routes.deckard.current_organization"
  ],
  "api.routes.deckard.classify_upload": [
    "api.routes.deckard.authenticated",
    "fastapi.Depends",
    "fastapi.responses.JSONResponse",
    "fastapi.File"
  ]
  }
  ```
  
  Here's what it looks like when I generate the graph from this branch:
  
  ```json
  {
    "api.routes.deckard.authenticated": {
    "filepath": "/Users/malandrina/Source/nuanced/fake-id/api/routes/deckard.py",
    "callees": [
      "api.routes.deckard.current_organization"
    ]
  },
  "api.routes.deckard.classify_upload": {
    "filepath": "/Users/malandrina/Source/nuanced/fake-id/api/routes/deckard.py",
    "callees": [
      "api.routes.deckard.authenticated",
      "fastapi.File",
      "fastapi.responses.JSONResponse",
      "fastapi.Depends"
    ]
  }
  }
```