### PR TITLE
Prefer os.makedirs to os.mkdir

### DIFF
--- a/src/nuanced/code_graph.py
+++ b/src/nuanced/code_graph.py
@@ -49,7 +49,7 @@ class CodeGraph():
                         try:
                             call_graph_dict = call_graph.to_dict()
                             nuanced_dirpath = f'{absolute_path}/{cls.NUANCED_DIRNAME}'
-                            os.mkdir(nuanced_dirpath, exist_ok=True)
+                            os.makedirs(nuanced_dirpath, exist_ok=True)
 
                             nuanced_graph_file = open(f'{nuanced_dirpath}/{cls.NUANCED_GRAPH_FILENAME}', "w+")
                             nuanced_graph_file.write(json.dumps(call_graph_dict))

--- a/tests/nuanced/code_graph_test.py
+++ b/tests/nuanced/code_graph_test.py
@@ -5,7 +5,7 @@ from nuanced import CodeGraph
 from nuanced.lib.call_graph import CallGraph
 
 def test_init_with_valid_path(mocker) -> None:
-    mocker.patch("os.mkdir", lambda _dirname, exist_ok=False: None)
+    mocker.patch("os.makedirs", lambda _dirname, exist_ok=True: None)
     mock_file = mocker.mock_open()
     mocker.patch("builtins.open", mock_file)
     path = "tests/fixtures"
@@ -38,8 +38,8 @@ def test_init_with_no_eligible_files_returns_errors(mocker) -> None:
     assert str(code_graph_result.errors[0]) == f"No eligible files found in {os.path.abspath(no_eligible_files_path)}"
 
 def test_init_with_valid_path_persists_code_graph(mocker) -> None:
-    mocker.patch("os.mkdir", lambda _dirname, exist_ok=False: None)
-    os_spy = mocker.spy(os, "mkdir")
+    mocker.patch("os.makedirs", lambda _dirname, exist_ok=True: None)
+    os_spy = mocker.spy(os, "makedirs")
     mock_file = mocker.mock_open()
     mocker.patch("builtins.open", mock_file)
     expected_path = os.path.abspath(f"tests/fixtures/{CodeGraph.NUANCED_DIRNAME}")
@@ -51,7 +51,7 @@ def test_init_with_valid_path_persists_code_graph(mocker) -> None:
     mock_file.assert_called_with(f'{expected_path}/{CodeGraph.NUANCED_GRAPH_FILENAME}', "w+")
 
 def test_init_with_valid_path_returns_code_graph(mocker) -> None:
-    mocker.patch("os.mkdir", lambda _dirname, exist_ok=False: None)
+    mocker.patch("os.makedirs", lambda _dirname, exist_ok=True: None)
     mock_file = mocker.mock_open()
     mocker.patch("builtins.open", mock_file)
     path = "tests/fixtures"


### PR DESCRIPTION
Summary of changes:

* `os.mkdir` was used by mistake for creating the `.nuanced` directory: we want to use `os.makedirs` because it supports the `exist_ok` keyword argument, which suppresses the `FileExistsError` that is raised in the case where the directory already exists
* ref: https://docs.python.org/3/library/os.html#os.makedirs