### PR TITLE
Use rich.print to prettify CLI output

### DIFF
--- a/src/nuanced/cli.py
+++ b/src/nuanced/cli.py
@@ -1,6 +1,7 @@
 import json
 import os
 import typer
+from rich import print
 from nuanced import CodeGraph
 
 app = typer.Typer()
@@ -16,7 +17,7 @@ def enrich(function_definition_path: str):
     if not result:
         print(f"\"{function_definition_path}\" not found")
     else:
-        print(json.dumps(result))
+        print(result)
 
 @app.command()
 def init(path: str):


### PR DESCRIPTION
Typer recommends using [rich](https://rich.readthedocs.io/en/stable/) to prettify printed output: https://typer.tiangolo.com/tutorial/printing/.

This PR updates the CLI to use `rich.print` instead of `print`.

![Screenshot 2025-02-18 at 4 29 43 PM](https://github.com/user-attachments/assets/b5ed283a-f5cc-4324-a9db-e6f36d9727a6)
