### PR TITLE
Use multiprocessing to generate call graph with timeout

### DIFF
--- a/src/nuanced/lib/call_graph.py
+++ b/src/nuanced/lib/call_graph.py
@@ -1,33 +1,29 @@
 from jarviscg import formats
 from jarviscg.core import CallGraphGenerator
 
-class CallGraph():
-    def __init__(self, entry_points: list, **kwargs):
-        default_package = None
-        default_decy = False
-        default_precision = False
-        default_module_entry = None
+def generate(entry_points: list, **kwargs):
+    default_package = None
+    default_decy = False
+    default_precision = False
+    default_module_entry = None
 
-        args = {
-                "package": default_package,
-                "decy": default_decy,
-                "precision": default_precision,
-                "moduleEntry": default_module_entry,
-            }
-        args.update(kwargs)
+    args = {
+            "package": default_package,
+            "decy": default_decy,
+            "precision": default_precision,
+            "moduleEntry": default_module_entry,
+        }
+    args.update(kwargs)
 
-        call_graph = CallGraphGenerator(
-            entry_points,
-            args["package"],
-            decy=args["decy"],
-            precision=args["precision"],
-            moduleEntry=args["moduleEntry"],
-        )
-        self.call_graph = call_graph
+    call_graph = CallGraphGenerator(
+        entry_points,
+        args["package"],
+        decy=args["decy"],
+        precision=args["precision"],
+        moduleEntry=args["moduleEntry"],
+    )
+    call_graph.analyze()
 
-    def generate(self) -> None:
-        self.call_graph.analyze()
-
-    def to_dict(self) -> dict:
-        formatter = formats.Nuanced(self.call_graph)
-        return formatter.generate()
+    formatter = formats.Nuanced(call_graph)
+    call_graph_dict = formatter.generate()
+    return call_graph_dict

--- a/src/nuanced/lib/utils.py
+++ b/src/nuanced/lib/utils.py
@@ -1,0 +1,35 @@
+from collections import namedtuple
+import multiprocessing
+import select
+
+WithTimeoutResult = namedtuple("WithTimeoutResult", ["errors", "value"])
+
+def send_target_return_value_to_conn(conn, target, args):
+    return_value = target(args)
+    conn.send(return_value)
+    conn.close()
+
+def with_timeout(target, args, timeout):
+    errors = []
+    value = None
+
+    parent_conn, child_conn = multiprocessing.Pipe()
+    process = multiprocessing.Process(
+       target=send_target_return_value_to_conn,
+       args=(child_conn, target, args)
+    )
+    process.start()
+
+    readable, _, _ = select.select([parent_conn], [], [], timeout)
+
+    if readable:
+        value = parent_conn.recv()
+        parent_conn.close()
+    else:
+        process.terminate()
+        parent_conn.close()
+        errors.append(multiprocessing.TimeoutError("Operation timed out"))
+
+    process.join()
+
+    return WithTimeoutResult(errors=errors, value=value)

--- a/tests/nuanced/call_graph_test.py
+++ b/tests/nuanced/call_graph_test.py
@@ -1,11 +1,31 @@
+from deepdiff import DeepDiff
 import inspect
 import pytest
-from nuanced.lib.call_graph import CallGraph
+from nuanced.lib import call_graph
 from tests.fixtures.fixture_class import FixtureClass
 
-def test_init_with_defaults() -> None:
+def test_generate_with_defaults_returns_call_graph_dict() -> None:
     entry_points = [inspect.getfile(FixtureClass)]
+    expected = {
+        "tests.fixtures.fixture_class": {
+            "filepath": "/Users/malandrina/Source/nuanced/nuanced-graph/tests/fixtures/fixture_class.py",
+            "callees": ["tests.fixtures.fixture_class.FixtureClass"]
+        },
+        "tests.fixtures.fixture_class.FixtureClass.__init__": {
+            "filepath": "/Users/malandrina/Source/nuanced/nuanced-graph/tests/fixtures/fixture_class.py",
+            "callees": []
+        },
+        "tests.fixtures.fixture_class.FixtureClass.foo": {
+            "filepath": "/Users/malandrina/Source/nuanced/nuanced-graph/tests/fixtures/fixture_class.py",
+            "callees": []
+        },
+        "tests.fixtures.fixture_class.FixtureClass.bar": {
+            "filepath": "/Users/malandrina/Source/nuanced/nuanced-graph/tests/fixtures/fixture_class.py",
+            "callees": ["tests.fixtures.fixture_class.FixtureClass.foo"]
+        }
+    }
 
-    call_graph = CallGraph(entry_points)
+    call_graph_dict = call_graph.generate(entry_points)
+    diff = DeepDiff(call_graph_dict, expected)
 
-    assert call_graph.call_graph.entry_points == entry_points
+    assert diff == {}


### PR DESCRIPTION
## Why?

As described in https://github.com/nuanced-dev/nuanced-graph/issues/26, currently the timeout handling in `CodeGraph.init` doesn't work: call graph generation is not terminated once the timeout threshold has been exceeded.

## How?

Summary of changes:

* Rewrite call graph generation business logic to use `multiprocessing` instead of `concurrent.futures`. The implementation using concurrent.futures correctly tracked the time elapsed but did not terminate the call graph generation process. Implementing the desired behavior seemed more straightforward using the multiprocessing module, so that's what I did.
* Introduce `nuanced.lib.utils.with_timeout` utility function for executing a function with a timeout and ensuring the function is stopped when the timeout is exceeded
* Refactor `nuanced.lib.call_graph` for compatibility with `multiprocessing.Process`:
  - Remove `CallGraph` object and method definitions
  - Introduce top-level `generate` function
  - Why? Because `multiprocessing.Process` only accepts targets that are "pickleable", i.e. 1) are defined at the top level of a module and 2) return values that can be serialized
* Update `CodeGraph` tests with test doubles that allow us to bypass exercising the multiprocessing-dependent code because pytest does not play nicely with multiprocessing
* Remove exception handling around creating `.nuanced/nuanced-graph.json` in `CodeGraph.init` because if anything were to go wrong at that point in the `init` process it would be truly exceptional and we want to treat it as such

## Considerations

Coming from Ruby, where setting a timeout on a process looks like this ([docs](https://ruby-doc.org/3.4.1/stdlibs/timeout/Timeout.html)):

```ruby
require "timeout"
status = Timeout.timeout(5) {
  call_graph.generate
}
```

... I was surprised to learn that it's relatively complicated in Python. A number of decisions are expressed in my implementation:

- I wrote a `with_timeout` function instead of a decorator because while decorators might be more idiomatic I find them harder to reason about
- I chose not to write any automated tests for `with_timeout` because they would just be a lot of mocking and stubbing which is of limited value when what you actually care about is whether the process ends when it's supposed to
- The util function `send_target_return_value_to_conn` exists because we need to pass a pickleable function to `multiprocessing.Process` in `with_timeout` and I didn't want `call_graph.generate` to have to interact with the `conn`

## QA

I confirmed that everything works as expected by timing the executing of `nuanced init pandas` from my local `pandas` directory, which timed out after 30s, and `nuanced init .` from my `nuanced-graph` directory, which succeeded:

![Screenshot 2025-03-03 at 10 01 33 AM](https://github.com/user-attachments/assets/7222cb71-2b28-4acd-9886-6ec460fd0261)

Addresses https://github.com/nuanced-dev/nuanced-graph/issues/26

References for our future selves:
- https://stackoverflow.com/questions/53413326/how-to-return-values-from-process-or-thread-instances
- https://stackoverflow.com/questions/78460097/why-cant-threadpoolexecutor-timeout-a-long-running-expression
- https://stackoverflow.com/questions/10415028/how-can-i-get-the-return-value-of-a-function-passed-to-multiprocessing-process
- https://stackoverflow.com/questions/72766345/attributeerror-cant-pickle-local-object-in-multiprocessing
- https://www.reddit.com/r/learnpython/comments/1c4vxiw/python_multiprocessing/
- https://docs.python.org/3/library/multiprocessing.html