### PR TITLE
Enable hatch to locate and download jarviscg release on GitHub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.8"
 dependencies = [
     "setuptools>=75.3.0",
-    "jarviscg",
+    "jarviscg@https://github.com/nuanced-dev/jarviscg/archive/refs/tags/v0.1.0rc1.tar.gz",
     "typer>=0.15.1",
 ]
 
@@ -26,6 +26,9 @@ dev = [
     "pytest>=8.3.4",
     "pytest-mock>=3.14.0",
 ]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.pytest.ini_options]
 pythonpath = [


### PR DESCRIPTION
## Why?

After publishing nuanced v0.1.1 to PyPI I ran `uv tool install nuanced` to test installation. This error message was returned:

```
  × No solution found when resolving dependencies:
  ╰─▶ Because jarviscg was not found in the package registry and nuanced==0.1.1 depends on jarviscg, we can conclude that nuanced==0.1.1 cannot be used.
      And because only nuanced==0.1.1 is available and you require nuanced, we can conclude that your requirements are unsatisfiable.
```

This is because pyproject.toml configures uv to resolve the source for the jarviscg package, but it does not configure the build system we are using, [hatch](https://hatch.pypa.io/1.9/).

## How?

Update pyproject.toml to include URL of jarviscg v0.1.0rc1 archive.

## Testing

- Build nuanced using `python -m build`
- Install nuanced using `pip install nuanced/nuanced-graph/dist/nuanced-0.1.2.tar.gz` (using pip instead of uv to verify the jarviscg source can be resolved)

![Screenshot 2025-03-04 at 1 54 26 PM](https://github.com/user-attachments/assets/cb25ea0a-09f1-4118-b265-98d163704753)

## Considerations

We'll have to bump nuanced to 0.1.2, publish to PyPI and yank 0.1.1.