### PR TITLE
Updates to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [
     { name = "Ayman Nadeem", email = "ayman@nuanced.dev" }
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "setuptools>=75.3.0",
     "jarviscg==0.1.0rc1",


### PR DESCRIPTION
## Why?

We learned that PyPI disallows "packages that declare dependencies using direct URLs" ([ref](https://github.com/nuanced-dev/nuanced/issues/45)), so we published jarviscg to PyPI and now need to update our pyproject.toml here to not reference jarviscg v0.1.0rc1's GitHub URL.

## How?

- Replace `"jarviscg@https://github.com/nuanced-dev/jarviscg/archive/refs/tags/v0.1.0rc1.tar.gz"` with `"jarviscg==0.1.0rc1"` in `dependencies` list
- Revert configuring hatch to allow direct references
- Remove jarviscg entry from `tool.uv.sources`

Unrelated to the build configuration:
 - Update minimum required Python version to 3.10 (workaround for https://github.com/nuanced-dev/nuanced/issues/37)
 
 ## Testing
 
 I verified I was able to install nuanced from this branch using `uv tool install`:
 
![Screenshot 2025-03-05 at 8 45 05 AM](https://github.com/user-attachments/assets/e8bb5e1b-915f-4928-bd17-fdfabebb3af6)
