### PR TITLE
`enrich` command searches for graph file in working dir and subdirs

### DIFF
--- a/src/nuanced/cli.py
+++ b/src/nuanced/cli.py
@@ -1,6 +1,7 @@
 import json
 import os
 import typer
+from pathlib import Path
 from rich import print
 from nuanced import CodeGraph
 
@@ -10,10 +11,15 @@ ERROR_EXIT_CODE = 1
 
 @app.command()
 def enrich(file_path: str, function_name: str):
-    nuanced_graph_path = os.path.abspath(".nuanced/nuanced-graph.json")
-    nuanced_graph_file = open(nuanced_graph_path, "r")
-    call_graph = json.load(nuanced_graph_file)
-    code_graph = CodeGraph(graph=call_graph)
+    inferred_graph_dir = "."
+    code_graph_result = CodeGraph.load(directory=inferred_graph_dir)
+
+    if len(code_graph_result.errors) > 0:
+        for error in code_graph_result.errors:
+            print(str(error))
+        raise typer.Exit(code=ERROR_EXIT_CODE)
+
+    code_graph = code_graph_result.code_graph
     result = code_graph.enrich(file_path=file_path, function_name=function_name)
 
     if len(result.errors) > 0:

--- a/src/nuanced/cli.py
+++ b/src/nuanced/cli.py
@@ -6,6 +6,8 @@ from nuanced import CodeGraph
 
 app = typer.Typer()
 
+ERROR_EXIT_CODE = 1
+
 @app.command()
 def enrich(file_path: str, function_name: str):
     nuanced_graph_path = os.path.abspath(".nuanced/nuanced-graph.json")
@@ -17,8 +19,10 @@ def enrich(file_path: str, function_name: str):
     if len(result.errors) > 0:
         for error in result.errors:
             print(str(error))
+        raise typer.Exit(code=ERROR_EXIT_CODE)
     elif not result.result:
         print(f"Function definition for file path \"{file_path}\" and function name \"{function_name}\" not found")
+        raise typer.Exit(code=ERROR_EXIT_CODE)
     else:
         print(json.dumps(result.result))
 

--- a/src/nuanced/code_graph.py
+++ b/src/nuanced/code_graph.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from itertools import groupby
+from pathlib import Path
 import errno
 import glob
 import json
@@ -58,6 +59,28 @@ class CodeGraph():
                     nuanced_graph_file = open(f'{nuanced_dirpath}/{cls.NUANCED_GRAPH_FILENAME}', "w+")
                     nuanced_graph_file.write(json.dumps(call_graph_dict))
                     code_graph = cls(graph=call_graph_dict)
+
+        return CodeGraphResult(code_graph=code_graph, errors=errors)
+
+    @classmethod
+    def load(cls, directory=str) -> CodeGraphResult:
+        errors = []
+        code_graph = None
+        dir_path = Path(directory)
+        file_paths = list(dir_path.glob(f"**/{cls.NUANCED_DIRNAME}/{cls.NUANCED_GRAPH_FILENAME}"))
+
+        if len(file_paths) > 1:
+            graph_file_paths = ", ".join([str(fp) for fp in file_paths])
+            error = ValueError(f"Multiple Nuanced Graphs found in {os.path.abspath(directory)}: {graph_file_paths}")
+            errors.append(error)
+        elif len(file_paths) == 1:
+            file_path = file_paths[0]
+            graph_file = open(file_path, "r")
+            graph = json.load(graph_file)
+            code_graph = CodeGraph(graph=graph)
+        elif len(file_paths) == 0:
+            error = FileNotFoundError(f"Nuanced Graph not found in {os.path.abspath(directory)}")
+            errors.append(error)
 
         return CodeGraphResult(code_graph=code_graph, errors=errors)
 

--- a/tests/nuanced/call_graph_test.py
+++ b/tests/nuanced/call_graph_test.py
@@ -1,5 +1,6 @@
 from deepdiff import DeepDiff
 import inspect
+import os
 import pytest
 from nuanced.lib import call_graph
 from tests.fixtures.fixture_class import FixtureClass
@@ -8,19 +9,19 @@ def test_generate_with_defaults_returns_call_graph_dict() -> None:
     entry_points = [inspect.getfile(FixtureClass)]
     expected = {
         "tests.fixtures.fixture_class": {
-            "filepath": "/Users/malandrina/Source/nuanced/nuanced-graph/tests/fixtures/fixture_class.py",
+            "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": ["tests.fixtures.fixture_class.FixtureClass"]
         },
         "tests.fixtures.fixture_class.FixtureClass.__init__": {
-            "filepath": "/Users/malandrina/Source/nuanced/nuanced-graph/tests/fixtures/fixture_class.py",
+            "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": []
         },
         "tests.fixtures.fixture_class.FixtureClass.foo": {
-            "filepath": "/Users/malandrina/Source/nuanced/nuanced-graph/tests/fixtures/fixture_class.py",
+            "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": []
         },
         "tests.fixtures.fixture_class.FixtureClass.bar": {
-            "filepath": "/Users/malandrina/Source/nuanced/nuanced-graph/tests/fixtures/fixture_class.py",
+            "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": ["tests.fixtures.fixture_class.FixtureClass.foo"]
         }
     }

--- a/tests/nuanced/cli_test.py
+++ b/tests/nuanced/cli_test.py
@@ -1,0 +1,38 @@
+from deepdiff import DeepDiff
+import json
+import os
+from typer.testing import CliRunner
+
+from nuanced.cli import app
+
+runner = CliRunner()
+
+def test_enrich_infers_path_to_nuanced_graph_success(mocker):
+    mock_file = mocker.mock_open()
+    mocker.patch("builtins.open", mock_file)
+    expected_output = {
+        "foo.bar": {
+            "filepath": os.path.abspath("foo.py"),
+            "callees": ["foo.baz"]
+        },
+        "foo.baz": {
+            "filepath": os.path.abspath("foo.py"),
+            "callees": [],
+        },
+    }
+    mocker.patch("json.load", lambda _x: expected_output)
+
+    result = runner.invoke(app, ["enrich", "foo.py", "bar"])
+    result_stdout = json.load(result.stdout)
+    diff = DeepDiff(result_stdout, expected_output)
+
+    assert diff == {}
+    assert result.exit_code == 0
+
+def test_enrich_infers_path_to_nuanced_graph_failure():
+    expected_output = 'Function definition for file path "foo.py" and function name "bar" not found\n'
+
+    result = runner.invoke(app, ["enrich", "foo.py", "bar"])
+
+    assert expected_output in result.stdout
+    assert result.exit_code == 1


### PR DESCRIPTION
## Why?

As documented in https://github.com/nuanced-dev/nuanced/issues/52, the way nuanced handles file and directory paths is confusing. As a first step toward improving the CLI user experience we're changing the way `nuanced enrich` finds the persisted graph.

## How?

**Before**

`nuanced enrich` attempted to load the graph from the absolute path of the current working directory with no error handling

**After**

`nuanced enrich` searches for _all_ `.nuanced/nuanced-graph.json` files in the current working directory and its subdirectories:
- if exactly one is found, the file contents are loaded into memory and queried
- if more than one is found, an error message is printed: `Multiple Nuanced Graphs found in <dir>: <list_of_found_files>`
- if none are found, an error message is printed: `Nuanced Graph not found in <dir>`

## Considerations

Pros of this solution:
- No breaking changes
- Doesn't require users to change their usage patterns
- Provides actionable information about expected usage

Cons:
- Not configurable
- Still kind of confusing
- Terminal output does not include hints

Alternatives that would require more design, time to implement (and would also change the interface):
- Support for specifying the location of the persisted graph in some kind of nuanced config file
- Support for passing the path of the persisted graph to `enrich`

## Testing

Lots of automated test, and some QA:

![Screenshot 2025-03-07 at 1 39 55 PM](https://github.com/user-attachments/assets/af24f9fa-e4fd-49b8-abf9-a97470ebfffa)
