### PR TITLE
Add version bump PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/version_bump_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/version_bump_template.md
@@ -1,0 +1,15 @@
+Pre-review checklist:
+- [ ] The version number in `pyproject.toml` has been updated
+- [ ] `__version__` in `src/nuanced/__init__.py` has been updated
+- [ ] `uv.lock` has been updated by running `uv sync`
+- [ ] `CHANGELOG.md` has been updated
+
+Post-merge checklist:
+- [ ] Create GitHub Release
+- [ ] Publish package to PyPI
+- [ ] Verify installation
+  - [ ] `pip install nuanced`
+  - [ ] `uv tool install nuanced`
+
+References:
+ - [nuanced Release Process](https://docs.nuanced.dev/versioning#release-process)

--- a/.github/PULL_REQUEST_TEMPLATE/version_bump_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/version_bump_template.md
@@ -6,6 +6,7 @@ Pre-review checklist:
 
 Post-merge checklist:
 - [ ] Create GitHub Release
+- [ ] Publish package to TestPyPI
 - [ ] Publish package to PyPI
 - [ ] Verify installation
   - [ ] `pip install nuanced`


### PR DESCRIPTION
Updates to four different files are required for every version bump and I invariably forget at least one every time. This PR introduces a PR template for nuanced package version bumps:

- One "pre-review" checklist to help us remember to update everything
- One "post-merge" checklist to help us verify all necessary release + publication steps were taken

I followed these instructions for creating a PR templates: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository