### PR TITLE
Add some type hints and address linting errors

### DIFF
--- a/src/nuanced/cli.py
+++ b/src/nuanced/cli.py
@@ -1,7 +1,6 @@
 import json
 import os
 import typer
-from pathlib import Path
 from rich import print
 from nuanced import CodeGraph
 
@@ -9,8 +8,9 @@ app = typer.Typer()
 
 ERROR_EXIT_CODE = 1
 
+
 @app.command()
-def enrich(file_path: str, function_name: str):
+def enrich(file_path: str, function_name: str) -> None:
     inferred_graph_dir = "."
     code_graph_result = CodeGraph.load(directory=inferred_graph_dir)
 
@@ -32,8 +32,9 @@ def enrich(file_path: str, function_name: str):
     else:
         print(json.dumps(result.result))
 
+
 @app.command()
-def init(path: str):
+def init(path: str) -> None:
     abspath = os.path.abspath(path)
     print(f"Initializing {abspath}")
     result = CodeGraph.init(abspath)
@@ -44,5 +45,6 @@ def init(path: str):
     else:
         print("Done")
 
-def main():
+
+def main() -> None:
     app()

--- a/src/nuanced/code_graph.py
+++ b/src/nuanced/code_graph.py
@@ -11,6 +11,7 @@ from nuanced.lib.utils import with_timeout
 CodeGraphResult = namedtuple("CodeGraphResult", ["errors", "code_graph"])
 EnrichmentResult = namedtuple("EnrichmentResult", ["errors", "result"])
 
+
 class CodeGraph():
     ELIGIBLE_FILE_TYPE_PATTERN = "*.py"
     INIT_TIMEOUT_SECONDS = 30
@@ -84,7 +85,7 @@ class CodeGraph():
 
         return CodeGraphResult(code_graph=code_graph, errors=errors)
 
-    def __init__(self, graph:dict|None) -> None:
+    def __init__(self, graph: dict | None) -> None:
         self.graph = graph
 
     def enrich(self, file_path: str, function_name: str) -> EnrichmentResult:
@@ -106,7 +107,7 @@ class CodeGraph():
 
         return EnrichmentResult(errors=[], result=subgraph)
 
-    def _build_subgraph(self, entrypoint_node_key: str) -> dict|None:
+    def _build_subgraph(self, entrypoint_node_key: str) -> dict | None:
         subgraph = dict()
         visited = set()
         entrypoint_node = self.graph.get(entrypoint_node_key)

--- a/src/nuanced/lib/call_graph.py
+++ b/src/nuanced/lib/call_graph.py
@@ -1,7 +1,8 @@
 from jarviscg import formats
 from jarviscg.core import CallGraphGenerator
 
-def generate(entry_points: list, **kwargs):
+
+def generate(entry_points: list, **kwargs) -> dict:
     default_package = None
     default_decy = False
     default_precision = False

--- a/src/nuanced/lib/utils.py
+++ b/src/nuanced/lib/utils.py
@@ -4,10 +4,12 @@ import select
 
 WithTimeoutResult = namedtuple("WithTimeoutResult", ["errors", "value"])
 
+
 def send_target_return_value_to_conn(conn, target, args):
     return_value = target(args)
     conn.send(return_value)
     conn.close()
+
 
 def with_timeout(target, args, timeout):
     errors = []


### PR DESCRIPTION
## Why?

Being consistent about including type hints in function definitions is helpful. It's less clear that always annotating variable assignments with type hints is helpful so I opted not to do that.

## How?

- Add type hints
- Address linting errors (unrelated to type hints)
- Don't make any changes to `src/nuanced/utils.py` to avoid merge conflicts with the contributor working on https://github.com/nuanced-dev/nuanced/issues/38

Addresses https://github.com/nuanced-dev/nuanced/issues/51