### PR TITLE
Mock file access in tests

### DIFF
--- a/tests/nuanced/cli_test.py
+++ b/tests/nuanced/cli_test.py
@@ -21,8 +21,14 @@ def test_enrich_loads_graph_from_working_dir(mocker):
 
     load_spy.assert_called_with(directory=".")
 
-def test_enrich_fails_to_load_graph_errors():
-    expected_output = f"Nuanced Graph not found in {os.path.abspath('./')}"
+def test_enrich_fails_to_load_graph_errors(mocker):
+    error = FileNotFoundError(f"Nuanced Graph not found in {os.path.abspath('./')}")
+    errors = [error]
+    mocker.patch(
+        "nuanced.cli.CodeGraph.load",
+        lambda directory: CodeGraphResult(code_graph=None, errors=errors),
+    )
+    expected_output = str(error)
 
     result = runner.invoke(app, ["enrich", "foo.py", "bar"])
 

--- a/tests/nuanced/code_graph_test.py
+++ b/tests/nuanced/code_graph_test.py
@@ -186,7 +186,8 @@ def test_load_multiple_files_found_errors(mocker, monkeypatch) -> None:
     assert type(result.errors[0]) == ValueError
     assert str(result.errors[0]) == expected_error_message
 
-def test_load_file_not_found_errors(mocker) -> None:
+def test_load_file_not_found_errors(monkeypatch) -> None:
+    monkeypatch.setattr(Path, "glob", lambda _x, _y: [])
     result = CodeGraph.load(directory=".")
 
     assert len(result.errors) == 1


### PR DESCRIPTION
Currently if `.nuanced/nuanced-graph.json` exists in my local nuanced directory the following tests fail because when they access the (real) filesystem nuanced-graph.json is there when it's not expected to be:

- `test_enrich_fails_to_load_graph_errors` in tests/nuanced/cli_test.py
- `test_load_file_not_found_errors ` in tests/nuanced/code_graph_test.py

This PR updates the setup phase of those tests appropriately.