### PR TITLE
Update CodeGraph.init to ensure input path is a directory containing a package definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.10"
 dependencies = [
     "setuptools>=75.3.0",
-    "jarviscg==0.1.0rc3",
+    "jarviscg==0.1.0rc4",
     "typer>=0.15.1",
 ]
 

--- a/src/nuanced/lib/call_graph.py
+++ b/src/nuanced/lib/call_graph.py
@@ -9,12 +9,17 @@ def generate(entry_points: list, **kwargs) -> dict:
     default_module_entry = None
 
     args = {
-            "package": default_package,
-            "decy": default_decy,
-            "precision": default_precision,
-            "moduleEntry": default_module_entry,
-        }
-    args.update(kwargs)
+        "package": default_package,
+        "decy": default_decy,
+        "precision": default_precision,
+        "moduleEntry": default_module_entry,
+    }
+    package_path = kwargs.get("package_path", None)
+
+    if package_path:
+        package_path_parts = package_path.split("/")
+        package_parent_path = "/".join(package_path_parts[0:-1])
+        args["package"] = package_parent_path
 
     call_graph = CallGraphGenerator(
         entry_points,

--- a/src/nuanced/lib/call_graph.py
+++ b/src/nuanced/lib/call_graph.py
@@ -3,16 +3,11 @@ from jarviscg.core import CallGraphGenerator
 
 
 def generate(entry_points: list, **kwargs) -> dict:
-    default_package = None
-    default_decy = False
-    default_precision = False
-    default_module_entry = None
-
     args = {
-        "package": default_package,
-        "decy": default_decy,
-        "precision": default_precision,
-        "moduleEntry": default_module_entry,
+        "package": None,
+        "decy": False,
+        "precision": False,
+        "moduleEntry": None,
     }
     package_path = kwargs.get("package_path", None)
 

--- a/src/nuanced/lib/utils.py
+++ b/src/nuanced/lib/utils.py
@@ -5,20 +5,20 @@ import select
 WithTimeoutResult = namedtuple("WithTimeoutResult", ["errors", "value"])
 
 
-def send_target_return_value_to_conn(conn, target, args):
-    return_value = target(args)
+def send_target_return_value_to_conn(conn, target, args, kwargs):
+    return_value = target(args, **kwargs)
     conn.send(return_value)
     conn.close()
 
 
-def with_timeout(target, args, timeout):
+def with_timeout(target, args, kwargs, timeout):
     errors = []
     value = None
 
     parent_conn, child_conn = multiprocessing.Pipe()
     process = multiprocessing.Process(
        target=send_target_return_value_to_conn,
-       args=(child_conn, target, args)
+       args=(child_conn, target, args, kwargs),
     )
     process.start()
 

--- a/tests/nuanced/call_graph_test.py
+++ b/tests/nuanced/call_graph_test.py
@@ -35,6 +35,42 @@ def test_generate_with_defaults_returns_call_graph_dict() -> None:
     }
 
     call_graph_dict = call_graph.generate(entry_points)
+
+    diff = DeepDiff(call_graph_dict, expected)
+
+    assert diff == {}
+
+def test_generate_with_package_returns_call_graph_dict() -> None:
+    entry_points = [inspect.getfile(FixtureClass)]
+    expected = {
+        "fixtures.fixture_class": {
+            "filepath": os.path.abspath("fixtures/fixture_class.py"),
+            "callees": ["fixtures.fixture_class.FixtureClass"],
+            "lineno": 1,
+            "end_lineno": 11,
+        },
+        "fixtures.fixture_class.FixtureClass.__init__": {
+            "filepath": os.path.abspath("fixtures/fixture_class.py"),
+            "callees": [],
+            "lineno": 4,
+            "end_lineno": 5,
+        },
+        "fixtures.fixture_class.FixtureClass.foo": {
+            "filepath": os.path.abspath("fixtures/fixture_class.py"),
+            "callees": [],
+            "lineno": 7,
+            "end_lineno": 8,
+        },
+        "fixtures.fixture_class.FixtureClass.bar": {
+            "filepath": os.path.abspath("fixtures/fixture_class.py"),
+            "callees": ["fixtures.fixture_class.FixtureClass.foo"],
+            "lineno": 10,
+            "end_lineno": 11,
+        }
+    }
+
+    call_graph_dict = call_graph.generate(entry_points, package_path="tests/fixtures")
+
     diff = DeepDiff(call_graph_dict, expected)
 
     assert diff == {}

--- a/tests/nuanced/call_graph_test.py
+++ b/tests/nuanced/call_graph_test.py
@@ -44,25 +44,25 @@ def test_generate_with_package_returns_call_graph_dict() -> None:
     entry_points = [inspect.getfile(FixtureClass)]
     expected = {
         "fixtures.fixture_class": {
-            "filepath": os.path.abspath("fixtures/fixture_class.py"),
+            "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": ["fixtures.fixture_class.FixtureClass"],
             "lineno": 1,
             "end_lineno": 11,
         },
         "fixtures.fixture_class.FixtureClass.__init__": {
-            "filepath": os.path.abspath("fixtures/fixture_class.py"),
+            "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": [],
             "lineno": 4,
             "end_lineno": 5,
         },
         "fixtures.fixture_class.FixtureClass.foo": {
-            "filepath": os.path.abspath("fixtures/fixture_class.py"),
+            "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": [],
             "lineno": 7,
             "end_lineno": 8,
         },
         "fixtures.fixture_class.FixtureClass.bar": {
-            "filepath": os.path.abspath("fixtures/fixture_class.py"),
+            "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": ["fixtures.fixture_class.FixtureClass.foo"],
             "lineno": 10,
             "end_lineno": 11,

--- a/uv.lock
+++ b/uv.lock
@@ -54,16 +54,16 @@ wheels = [
 
 [[package]]
 name = "jarviscg"
-version = "0.1.0rc3"
+version = "0.1.0rc4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deepdiff" },
     { name = "pytest" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/ea/31a2b0c08155f48879b0d77fb19b09fec03501cb1e203020de8c06b90a8d/jarviscg-0.1.0rc3.tar.gz", hash = "sha256:a35266a1c3ac8aa13cad4897c5d25515a525c012bbae0bae239f58b22b7c12c0", size = 54269312 }
+sdist = { url = "https://files.pythonhosted.org/packages/27/c1/7c67b96c1702a1da718607beabcb1a2a0656cdabee88f8f8678073fcd236/jarviscg-0.1.0rc4.tar.gz", hash = "sha256:69cf276f42fa6d2bc54c35abd98284f2725ce5b74b11ccd406d4966fdf04d9d4", size = 54269229 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/7a/ab1892c9f268a9b0803afbdd1e681440be053c308223395aab426220524e/jarviscg-0.1.0rc3-py3-none-any.whl", hash = "sha256:f78c37c8ab4e36966d3c420b359dd60afd753fb9b9c2ab7afebe1cdd4d6e635b", size = 49481 },
+    { url = "https://files.pythonhosted.org/packages/1e/ca/dab93c2d6b46cc42d102c646343f598c31abff0b8a9fb384e28415fe5bd7/jarviscg-0.1.0rc4-py3-none-any.whl", hash = "sha256:122901d72eb0335e278c21c80ef9ad739a2fe04ed0d94c73f039acd5572268a8", size = 49476 },
 ]
 
 [[package]]
@@ -106,7 +106,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "jarviscg", specifier = "==0.1.0rc3" },
+    { name = "jarviscg", specifier = "==0.1.0rc4" },
     { name = "setuptools", specifier = ">=75.3.0" },
     { name = "typer", specifier = ">=0.15.1" },
 ]


### PR DESCRIPTION
## Why?

Permitted usage of nuanced's `init` functionality isn't aligned with what jarviscg expects. We have found that jarviscg's ability to map edges between imported/importing modules is negatively impacted when the collection of files it's operating on doesn't conform to a structure that looks like this:

```
.
└── my_package
    ├── __init__.py
    ├── my_module.py
    └── my_sub_package
        ├── __init__.py
        └── my_sub_package_module.py
```
This PR updates `CodeGraph.init` to be stricter about acceptable usage.

## How?

- `CodeGraph.init` returns an error if the input path is a directory with no package definition, i.e. `__init__.py` file
- `CodeGraph.init` passes the valid package path to `call_graph.generate`
- `call_graph.generate` sets jarviscg's `package` option to the name of the package's _parent directory_. Why? Because that is the incantation that consistently produces good results 🤷‍♀️ Setting `package` to the package path produces a graph in which the name of the package is not included in the fully qualified function names, e.g. `code_graph.CodeGraph` instead of `nuanced.code_graph.CodeGraph`.

### Before

Users can `init` wherever and hope the graph isn't broken!

```bash
(nuanced) nuanced main % nuanced init .
Initializing /Users/laila/Source/nuanced/nuanced
Done
(nuanced) nuanced main % nuanced enrich src/nuanced/cli.py enrich | jq
{
  "src.nuanced.cli.enrich": {
    "filepath": "/Users/laila/Source/nuanced/nuanced/src/nuanced/cli.py",
    "callees": [
      "<builtin>.len",
      "<builtin>.print",
      "<builtin>.str"
    ],
    "lineno": 13,
    "end_lineno": 33
  }
}
```

### After

Users must `init` with a directory that contains an `__init__.py` file, but we have far higher confidence that the graph for the package is as complete as possible.

```bash
(nuanced) nuanced lw-init % nuanced init .
Initializing /Users/laila/Source/nuanced/nuanced
No package definition found in /Users/laila/Source/nuanced/nuanced: `__init__.py` missing
(nuanced) nuanced lw-init % nuanced init src
Initializing /Users/laila/Source/nuanced/nuanced/src
No package definition found in /Users/laila/Source/nuanced/nuanced/src: `__init__.py` missing
(nuanced) nuanced lw-init % nuanced init src/nuanced
Initializing /Users/laila/Source/nuanced/nuanced/src/nuanced
Done
(nuanced) nuanced lw-init % nuanced enrich src/nuanced/cli.py enrich | jq
{
  "nuanced.cli.enrich": {
    "filepath": "/Users/laila/Source/nuanced/nuanced/src/nuanced/cli.py",
    "callees": [
      "nuanced.code_graph.CodeGraph.load",
      "<builtin>.len",
      "<builtin>.print",
      "<builtin>.str"
    ],
    "lineno": 13,
    "end_lineno": 33
  },
  "nuanced.code_graph.CodeGraph.load": {
    "filepath": "/Users/laila/Source/nuanced/nuanced/src/nuanced/code_graph.py",
    "callees": [
      "<builtin>.len",
      "<builtin>.list",
      "<builtin>.FileNotFoundError",
      "nuanced.code_graph.CodeGraph.__init__",
      "pathlib.Path",
      "<builtin>.str",
      "<builtin>.ValueError",
      "<builtin>.open",
      "append"
    ],
    "lineno": 71,
    "end_lineno": 90
  },
  "nuanced.code_graph.CodeGraph.__init__": {
    "filepath": "/Users/laila/Source/nuanced/nuanced/src/nuanced/code_graph.py",
    "callees": [],
    "lineno": 92,
    "end_lineno": 93
  }
} 
```

## Considerations

This change increases the potential for confusion around how `enrich` works. For example, if I `nuanced init src/nuanced` and later decide I want to use nuanced for the `tests` package:

```bash
(nuanced) nuanced lw-init % ls src/nuanced/.nuanced
nuanced-graph.json
(nuanced) nuanced lw-init % nuanced init tests
Initializing /Users/laila/Source/nuanced/nuanced/tests
Done
(nuanced) nuanced lw-init % nuanced enrich src/nuanced/cli.py enrich
Multiple Nuanced Graphs found in /Users/laila/Source/nuanced/nuanced: tests/.nuanced/nuanced-graph.json, src/nuanced/.nuanced/nuanced-graph.json
```

Updates to `enrich` will be made in a separate PR.

Addresses https://github.com/nuanced-dev/nuanced/issues/52, https://github.com/nuanced-dev/nuanced/issues/62