### PR TITLE
Update enrich CLI command to search for relevant graph file

### DIFF
--- a/src/nuanced/cli.py
+++ b/src/nuanced/cli.py
@@ -53,7 +53,7 @@ def _find_code_graph(file_path: str) -> CodeGraphResult:
     if len(code_graph_result.errors) > 0:
         top_directory = file_directory.split("/")[0]
 
-        for root, dirs, _files in os.walk(top_directory):
+        for root, dirs, _files in os.walk(top_directory, topdown=False):
             commonprefix = os.path.commonprefix([root, file_directory])
 
             if commonprefix == root and CodeGraph.NUANCED_DIRNAME in dirs:

--- a/src/nuanced/cli.py
+++ b/src/nuanced/cli.py
@@ -3,6 +3,7 @@ import os
 import typer
 from rich import print
 from nuanced import CodeGraph
+from nuanced.code_graph import CodeGraphResult
 
 app = typer.Typer()
 
@@ -11,8 +12,7 @@ ERROR_EXIT_CODE = 1
 
 @app.command()
 def enrich(file_path: str, function_name: str) -> None:
-    inferred_graph_dir = "."
-    code_graph_result = CodeGraph.load(directory=inferred_graph_dir)
+    code_graph_result = _find_code_graph(file_path)
 
     if len(code_graph_result.errors) > 0:
         for error in code_graph_result.errors:
@@ -44,6 +44,23 @@ def init(path: str) -> None:
             print(str(error))
     else:
         print("Done")
+
+
+def _find_code_graph(file_path: str) -> CodeGraphResult:
+    file_directory, _file_name = os.path.split(file_path)
+    code_graph_result = CodeGraph.load(directory=file_directory)
+
+    if len(code_graph_result.errors) > 0:
+        top_directory = file_directory.split("/")[0]
+
+        for root, dirs, _files in os.walk(top_directory):
+            commonprefix = os.path.commonprefix([root, file_directory])
+
+            if commonprefix == root and CodeGraph.NUANCED_DIRNAME in dirs:
+                code_graph_result = CodeGraph.load(directory=root)
+                break
+
+    return code_graph_result
 
 
 def main() -> None:

--- a/tests/nuanced/cli_test.py
+++ b/tests/nuanced/cli_test.py
@@ -47,10 +47,10 @@ def test_enrich_finds_relevant_graph_in_file_path_scope(mocker):
     file_path = "../foo/bar/baz.py"
     file_dir, _ = os.path.split(file_path)
     top_dir = ".."
-    top_dir_contents = (top_dir, ["other", "foo"], ["__init__.py"])
-    file_parent_dir_contents = ("../foo", [CodeGraph.NUANCED_DIRNAME], ["__init__.py"])
-    other_dir_contents = ("../other", [CodeGraph.NUANCED_DIRNAME], ["__init__.py"])
-    file_dir_contents = (file_dir, [], ["__init__.py", "baz.py"])
+    top_dir_contents = (top_dir, ["other", "foo"], [])
+    file_parent_dir_contents = ("../foo", [CodeGraph.NUANCED_DIRNAME], [])
+    other_dir_contents = ("../other", [CodeGraph.NUANCED_DIRNAME], [])
+    file_dir_contents = (file_dir, [], [])
     stub_graph = {}
     result_with_errors = CodeGraphResult(code_graph=None, errors=["Graph not found"])
     valid_result = CodeGraphResult(code_graph=CodeGraph(stub_graph), errors=[])

--- a/tests/nuanced/cli_test.py
+++ b/tests/nuanced/cli_test.py
@@ -36,7 +36,7 @@ def test_enrich_finds_relevant_graph_in_file_path_parent_dir(mocker):
         "nuanced.cli.CodeGraph.load",
         lambda directory: result_with_errors if directory == file_dir else valid_result
     )
-    expected_calls = [mocker.call(directory=file_dir), mocker.call(directory=top_dir)]
+    expected_calls = [mocker.call(directory=file_dir)]
     load_spy = mocker.spy(CodeGraph, "load")
 
     runner.invoke(app, ["enrich", file_path, "hello_world"])


### PR DESCRIPTION
## Why?

We're moving from a paradigm in which `init` attempts to generate one graph file for multiple packages in a repo to a paradigm in which `init` generates one graph file per package, where the package is specified by the user: https://github.com/nuanced-dev/nuanced/pull/66 This approach is better aligned with jarviscg's intended usage and will give us greater confidence in the completeness of the graphs we generate.

Currently, when `nuanced enrich` is executed the (one) graph is assumed to be in the current working directory. If multiple graph files are found in the current working directory, an error message is returned.

This PR updates the `nuanced enrich` command to be smarter in its approach to locating the graph file that is relevant to the query.

## How?

Update `enrich` CLI command to:
- Attempt to load a graph from the directory in which the file in `file_path` is located
- If that doesn't work, traverse the directory structure starting with the top-level directory in `file_path`
  - For each directory, check if 1) it shares a prefix with the `file_path` directory path and 2) its directories include `.nuanced`
  - Exit traversal when these conditions have been met and graph has been loaded

## Considerations

I found it difficult to reason about scenarios where this approach to searching for the relevant graph file won't work and would like to hear others' thoughts.

## To do

There's no test exercising the `break` (early return) that is executed once the relevant graph is found.

Addresses https://github.com/nuanced-dev/nuanced/issues/52