### PR TITLE
Better formatting for CLI JSON output

### DIFF
--- a/src/nuanced/cli.py
+++ b/src/nuanced/cli.py
@@ -30,7 +30,7 @@ def enrich(file_path: str, function_name: str) -> None:
         print(f"Function definition for file path \"{file_path}\" and function name \"{function_name}\" not found")
         raise typer.Exit(code=ERROR_EXIT_CODE)
     else:
-        print(json.dumps(result.result))
+        print(json.dumps(result.result, indent=2))
 
 
 @app.command()


### PR DESCRIPTION
## Why?

The `nuanced enrich` CLI command currently does not format the JSON it outputs. We have developed the habit of relying on [jq](https://jqlang.org/) to do the formatting at the command line. Instead, `nuanced enrich` should output JSON that is (more) legible to humans.

## How?

Set `indent` option to 2 spaces when invoking `json.dumps(result.result)` in `enrich`.

**Before**

```bash
% nuanced enrich src/nuanced/lib/utils.py with_timeout
{"nuanced.lib.utils.with_timeout": {"filepath": "/Users/laila/Source/nuanced/nuanced/src/nuanced/lib/utils.py", "callees": ["append"], "lineno": 14, "end_lineno": 37}}
```

**After**

```bash
% nuanced enrich src/nuanced/lib/utils.py with_timeout
{
  "nuanced.lib.utils.with_timeout": {
    "filepath": "/Users/laila/Source/nuanced/nuanced/src/nuanced/lib/utils.py",
    "callees": [
      "append"
    ],
    "lineno": 14,
    "end_lineno": 37
  }
}
```