### PR TITLE
Print error messages to stderr

### DIFF
--- a/src/nuanced/cli.py
+++ b/src/nuanced/cli.py
@@ -2,6 +2,7 @@ import json
 import os
 import typer
 from rich import print
+from rich.console import Console
 from nuanced import CodeGraph
 from nuanced.code_graph import CodeGraphResult
 
@@ -12,11 +13,12 @@ ERROR_EXIT_CODE = 1
 
 @app.command()
 def enrich(file_path: str, function_name: str) -> None:
+    err_console = Console(stderr=True)
     code_graph_result = _find_code_graph(file_path)
 
     if len(code_graph_result.errors) > 0:
         for error in code_graph_result.errors:
-            print(str(error))
+            err_console.print(str(error))
         raise typer.Exit(code=ERROR_EXIT_CODE)
 
     code_graph = code_graph_result.code_graph
@@ -24,10 +26,11 @@ def enrich(file_path: str, function_name: str) -> None:
 
     if len(result.errors) > 0:
         for error in result.errors:
-            print(str(error))
+            err_console.print(str(error))
         raise typer.Exit(code=ERROR_EXIT_CODE)
     elif not result.result:
-        print(f"Function definition for file path \"{file_path}\" and function name \"{function_name}\" not found")
+        err_msg = "Function definition for file path \"{file_path}\" and function name \"{function_name}\" not found"
+        err_console.print(err_msg)
         raise typer.Exit(code=ERROR_EXIT_CODE)
     else:
         print(json.dumps(result.result, indent=2))
@@ -35,13 +38,14 @@ def enrich(file_path: str, function_name: str) -> None:
 
 @app.command()
 def init(path: str) -> None:
+    err_console = Console(stderr=True)
     abspath = os.path.abspath(path)
     print(f"Initializing {abspath}")
     result = CodeGraph.init(abspath)
 
     if len(result.errors) > 0:
         for error in result.errors:
-            print(str(error))
+            err_console.print(str(error))
     else:
         print("Done")
 

--- a/tests/nuanced/cli_test.py
+++ b/tests/nuanced/cli_test.py
@@ -7,7 +7,7 @@ from nuanced.cli import app
 from nuanced.code_graph import CodeGraphResult
 
 
-runner = CliRunner()
+runner = CliRunner(mix_stderr=False)
 
 
 def test_enrich_finds_relevant_graph_in_file_dir(mocker):
@@ -82,7 +82,7 @@ def test_enrich_fails_to_load_graph_errors(mocker):
 
     result = runner.invoke(app, ["enrich", "foo.py", "bar"])
 
-    assert expected_output in result.stdout
+    assert expected_output in result.stderr
     assert result.exit_code == 1
 
 def test_enrich_returns_subgraph_success(mocker):


### PR DESCRIPTION
## Why?

Our CLI commands should print error messages to STDERR, not STDOUT.

## How?

Follow Typer's instructions for using `rich.console.Console`'s `stderr` option to print to STDERR when appropriate: https://typer.tiangolo.com/tutorial/printing/#printing-to-standard-error, https://typer.tiangolo.com/tutorial/testing/#check-the-result

## Considerations

Looks like there are some untested cases where `enrich` prints error messages. I should probably add some test scenarios.