### PR TITLE
Increase graph initialization timeout threshold to 60s

### DIFF
--- a/src/nuanced/code_graph.py
+++ b/src/nuanced/code_graph.py
@@ -14,7 +14,7 @@ EnrichmentResult = namedtuple("EnrichmentResult", ["errors", "result"])
 
 class CodeGraph():
     ELIGIBLE_FILE_TYPE_PATTERN = "*.py"
-    INIT_TIMEOUT_SECONDS = 30
+    INIT_TIMEOUT_SECONDS = 60
     NUANCED_DIRNAME = ".nuanced"
     NUANCED_GRAPH_FILENAME = "nuanced-graph.json"
 


### PR DESCRIPTION
## Why?

I noticed that `nuanced init py-polars/polars` for the polars repo times out. When I increased the timeout threshold it completed in 46s.

In the absence of a configurable timeout threshold, which is on our roadmap but we're not there yet (https://github.com/nuanced-dev/nuanced/issues/57), I think we should increase the default threshold from 30s to 60s.

## How?

Update `CodeGraph.INIT_TIMEOUT_SECONDS`

Ref: https://github.com/nuanced-dev/nuanced-operations/issues/212