### PR TITLE
Upgrade to jarviscg v0.1.0rc5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
+    "jarviscg==0.1.0rc5",
     "setuptools>=75.3.0",
-    "jarviscg==0.1.0rc4",
     "typer>=0.15.1",
 ]
 

--- a/tests/nuanced/call_graph_test.py
+++ b/tests/nuanced/call_graph_test.py
@@ -22,7 +22,7 @@ def test_generate_with_defaults_returns_call_graph_dict() -> None:
         },
         "tests.fixtures.fixture_class.FixtureClass.foo": {
             "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
-            "callees": [],
+            "callees": ["datetime.datetime.tzinfo"],
             "lineno": 7,
             "end_lineno": 8,
         },
@@ -57,7 +57,7 @@ def test_generate_with_package_returns_call_graph_dict() -> None:
         },
         "fixtures.fixture_class.FixtureClass.foo": {
             "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
-            "callees": [],
+            "callees": ["datetime.datetime.tzinfo"],
             "lineno": 7,
             "end_lineno": 8,
         },

--- a/uv.lock
+++ b/uv.lock
@@ -55,16 +55,16 @@ wheels = [
 
 [[package]]
 name = "jarviscg"
-version = "0.1.0rc4"
+version = "0.1.0rc5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deepdiff" },
     { name = "pytest" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/c1/7c67b96c1702a1da718607beabcb1a2a0656cdabee88f8f8678073fcd236/jarviscg-0.1.0rc4.tar.gz", hash = "sha256:69cf276f42fa6d2bc54c35abd98284f2725ce5b74b11ccd406d4966fdf04d9d4", size = 54269229 }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/92/6943a61ddd491d7466144390bf2c0be2a1cad76e438ee26710d91ad510a9/jarviscg-0.1.0rc5.tar.gz", hash = "sha256:f7f2f0ca06f3052aef096b673cdc9988a5b673ff1e3ae813bc095ca21a4e4680", size = 54098729 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/ca/dab93c2d6b46cc42d102c646343f598c31abff0b8a9fb384e28415fe5bd7/jarviscg-0.1.0rc4-py3-none-any.whl", hash = "sha256:122901d72eb0335e278c21c80ef9ad739a2fe04ed0d94c73f039acd5572268a8", size = 49476 },
+    { url = "https://files.pythonhosted.org/packages/63/cd/60f2b116eccc22447edc34553225cb6894616be512580b89c8b9ea7bc02b/jarviscg-0.1.0rc5-py3-none-any.whl", hash = "sha256:587c757c5c7c440743019316c280eca0db029559074741ceb717c6cd16b4094e", size = 58020 },
 ]
 
 [[package]]
@@ -107,7 +107,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "jarviscg", specifier = "==0.1.0rc4" },
+    { name = "jarviscg", specifier = "==0.1.0rc5" },
     { name = "setuptools", specifier = ">=75.3.0" },
     { name = "typer", specifier = ">=0.15.1" },
 ]


### PR DESCRIPTION
## Why?

Call graphs generated with jarviscg v0.1.0rc5 include edges to imported modules' attributes (https://github.com/nuanced-dev/jarviscg/blob/main/CHANGELOG.md#010rc5---2025-06-04)

## How?

- Update test to reflect jarviscg behavior
- Update pyproject.toml and uv.lock