### PR TITLE
Exclude `builtins` from callees by default with the option to include them

### DIFF
--- a/src/nuanced/cli.py
+++ b/src/nuanced/cli.py
@@ -12,7 +12,11 @@ ERROR_EXIT_CODE = 1
 
 
 @app.command()
-def enrich(file_path: str, function_name: str) -> None:
+def enrich(
+    file_path: str,
+    function_name: str,
+    include_builtins: bool = typer.Option(False, "--include-builtins"),
+) -> None:
     err_console = Console(stderr=True)
     code_graph_result = _find_code_graph(file_path)
 
@@ -22,7 +26,11 @@ def enrich(file_path: str, function_name: str) -> None:
         raise typer.Exit(code=ERROR_EXIT_CODE)
 
     code_graph = code_graph_result.code_graph
-    result = code_graph.enrich(file_path=file_path, function_name=function_name)
+    result = code_graph.enrich(
+        file_path=file_path,
+        function_name=function_name,
+        include_builtins=include_builtins
+    )
 
     if len(result.errors) > 0:
         for error in result.errors:

--- a/src/nuanced/lib/call_graph.py
+++ b/src/nuanced/lib/call_graph.py
@@ -2,6 +2,8 @@ from jarviscg import formats
 from jarviscg.core import CallGraphGenerator
 
 
+BUILTIN_FUNCTION_PREFIX = "<builtin>"
+
 def generate(entry_points: list, **kwargs) -> dict:
     args = {
         "package": None,


### PR DESCRIPTION
## Why?

nuanced-ts excludes edges to native functions by default with the option to include them, and we've received feedback that nuanced Python's inclusion of these edges (`builtins` in Python) is noisy.

## How?

- Update `CodeGraph::enrich` to exclude callees starting with `<builtin>` by default
- Update `CodeGraph::enrich` to include callees starting with `<builtin>` if `include_builtins` option is `True`
- Update `nuanced enrich` CLI command to support `--include-builtins` flag
- Also update some graph node test fixtures to have `lineno` and `end_lineno` properties

## Considerations

jarviscg includes builtins when generating a call graph. `<builtin>` is the prefix jarviscg uses to denote builtin functions: https://github.com/nuanced-dev/jarviscg/blob/main/src/jarviscg/utils/constants.py#L16