### PR TITLE
Introduce --version CLI command

### DIFF
--- a/src/nuanced/cli.py
+++ b/src/nuanced/cli.py
@@ -3,7 +3,7 @@ import os
 import typer
 from rich import print
 from rich.console import Console
-from nuanced import CodeGraph
+from nuanced import CodeGraph, __version__
 from nuanced.code_graph import CodeGraphResult
 
 app = typer.Typer()
@@ -49,6 +49,20 @@ def init(path: str) -> None:
     else:
         print("Done")
 
+@app.callback(invoke_without_command=True)
+def cli(
+    ctx: typer.Context,
+    version: bool = typer.Option(
+        None,
+        "-v",
+        "--version",
+        is_eager=True,
+        help="Display nuanced version.",
+    ),
+):
+    if version:
+        print(f"nuanced {__version__}")
+        raise typer.Exit()
 
 def _find_code_graph(file_path: str) -> CodeGraphResult:
     file_directory, _file_name = os.path.split(file_path)

--- a/tests/nuanced/cli_test.py
+++ b/tests/nuanced/cli_test.py
@@ -2,13 +2,18 @@ from deepdiff import DeepDiff
 import json
 import os
 from typer.testing import CliRunner
-from nuanced import CodeGraph
+from nuanced import CodeGraph, __version__
 from nuanced.cli import app
 from nuanced.code_graph import CodeGraphResult, EnrichmentResult
 
 
 runner = CliRunner(mix_stderr=False)
 
+
+def test_version_displays_installed_version():
+    result = runner.invoke(app, ["--version"])
+
+    assert result.stdout == f"nuanced {__version__}\n"
 
 def test_enrich_finds_relevant_graph_in_file_dir(mocker):
     graph = { "foo.bar": { "filepath": os.path.abspath("foo.py"), "callees": [] } }


### PR DESCRIPTION
## Why?

Users should be able to run `nuanced --version` or `nuanced -v` to see which version of nuanced they're running instead of having to rely on `pip show` or `uv pip show`.

## How?

According to the internet there are a number of ways to achieve this using Typer and they're all based on Typer's "option callbacks" (docs: https://typer.tiangolo.com/tutorial/options/callback-and-context/). I went with what I thought was the most straightforward implementation (ref: `https://github.com/fastapi/typer/issues/372#issuecomment-1076144815`)