### PR TITLE
Permit graph initialization in non-package directories

### DIFF
--- a/src/nuanced/code_graph.py
+++ b/src/nuanced/code_graph.py
@@ -42,9 +42,6 @@ class CodeGraph():
             if len(eligible_absolute_filepaths) == 0:
                 error = ValueError(f"No eligible files found in {absolute_path_to_package}")
                 errors.append(error)
-            elif f"{absolute_path_to_package}/__init__.py" not in eligible_absolute_filepaths:
-                error = ValueError(f"No package definition found in {absolute_path_to_package}: `__init__.py` missing")
-                errors.append(error)
             else:
                 call_graph_result = with_timeout(
                     target=call_graph.generate,

--- a/tests/nuanced/code_graph_test.py
+++ b/tests/nuanced/code_graph_test.py
@@ -42,16 +42,6 @@ def test_init_with_valid_path_generates_graph_with_expected_files(mocker) -> Non
     for e in received_entry_points:
         assert e in expected_filepaths
 
-def test_init_with_no_package_definitions_in_directory_returns_errors(mocker) -> None:
-    path = "."
-    expected_error_message = f"No package definition found in {os.path.abspath(path)}: `__init__.py` missing"
-
-    code_graph_result = CodeGraph.init(path)
-
-    assert len(code_graph_result.errors) == 1
-    assert type(code_graph_result.errors[0]) == ValueError
-    assert str(code_graph_result.errors[0]) == expected_error_message
-
 def test_init_with_invalid_path_returns_errors(mocker) -> None:
     invalid_path = "foo"
 


### PR DESCRIPTION
## Why?

We want nuanced to be able to analyze and generate a call graph for all Python modules and packages in a codebase. Currently we only permit initializing a graph for one package.

Updates to the actual call graph generation business logic in `call_graph.generate` are underway in a separate branch; this PR updates `CodeGraph.init` to remove the requirement that the input `path` be a path to a directory defining a package.

## How?

- Update `CodeGraph.init`
- Remove outdated test

## Considerations

I'm proposing merging this into a feature branch, `project-analysis`, which will be merged to `main` when the feature is complete.

ref: https://github.com/nuanced-dev/nuanced/issues/72