### PR TITLE
enrich command always loads graph from working directory

### DIFF
--- a/src/nuanced/cli.py
+++ b/src/nuanced/cli.py
@@ -18,7 +18,8 @@ def enrich(
     include_builtins: bool = typer.Option(False, "--include-builtins"),
 ) -> None:
     err_console = Console(stderr=True)
-    code_graph_result = _find_code_graph(file_path)
+    inferred_graph_dir = "."
+    code_graph_result = CodeGraph.load(directory=inferred_graph_dir)
 
     if len(code_graph_result.errors) > 0:
         for error in code_graph_result.errors:
@@ -71,23 +72,6 @@ def cli(
     if version:
         print(f"nuanced {__version__}")
         raise typer.Exit()
-
-def _find_code_graph(file_path: str) -> CodeGraphResult:
-    file_directory, _file_name = os.path.split(file_path)
-    code_graph_result = CodeGraph.load(directory=file_directory)
-
-    if len(code_graph_result.errors) > 0:
-        top_directory = file_directory.split("/")[0]
-
-        for root, dirs, _files in os.walk(top_directory, topdown=False):
-            commonprefix = os.path.commonprefix([root, file_directory])
-
-            if commonprefix == root and CodeGraph.NUANCED_DIRNAME in dirs:
-                code_graph_result = CodeGraph.load(directory=root)
-                break
-
-    return code_graph_result
-
 
 def main() -> None:
     app()

--- a/tests/nuanced/cli_test.py
+++ b/tests/nuanced/cli_test.py
@@ -15,7 +15,7 @@ def test_version_displays_installed_version():
 
     assert result.stdout == f"nuanced {__version__}\n"
 
-def test_enrich_finds_relevant_graph_in_file_dir(mocker):
+def test_enrich_finds_relevant_graph_in_current_dir(mocker):
     graph = { "foo.bar": { "filepath": os.path.abspath("foo.py"), "callees": [] } }
     code_graph = CodeGraph(graph=graph)
     mocker.patch(
@@ -26,27 +26,7 @@ def test_enrich_finds_relevant_graph_in_file_dir(mocker):
 
     runner.invoke(app, ["enrich", "foo.py", "bar"])
 
-    load_spy.assert_called_with(directory="")
-
-def test_enrich_finds_relevant_graph_in_file_path_parent_dir(mocker):
-    file_path = "foo/bar/baz.py"
-    file_dir, _ = os.path.split(file_path)
-    top_dir = "foo"
-    top_dir_contents = (top_dir, [CodeGraph.NUANCED_DIRNAME, "bar"], ["__init__.py"])
-    stub_graph = {}
-    result_with_errors = CodeGraphResult(code_graph=None, errors=["Graph not found"])
-    valid_result = CodeGraphResult(code_graph=CodeGraph(stub_graph), errors=[])
-    mocker.patch("os.walk", lambda directory: [top_dir_contents])
-    mocker.patch(
-        "nuanced.cli.CodeGraph.load",
-        lambda directory: result_with_errors if directory == file_dir else valid_result
-    )
-    expected_calls = [mocker.call(directory=file_dir)]
-    load_spy = mocker.spy(CodeGraph, "load")
-
-    runner.invoke(app, ["enrich", file_path, "hello_world"])
-
-    load_spy.assert_has_calls(expected_calls)
+    load_spy.assert_called_with(directory=".")
 
 def test_enrich_finds_relevant_graph_in_file_path_scope(mocker):
     file_path = "../foo/bar/baz.py"


### PR DESCRIPTION
## Why?

We're moving to a strategy of generating and persisting one graph per codebase rather than one graph per Python package. We're going to proceed with the assumption that given this strategy, `CodeGraph::enrich` and `nuanced enrich` should load the (one) graph from the current working directory.

## How?

- Remove `_find_code_graph` from src/nuanced/cli.py and update `enrich` command to attempt to load graph from current directory

## Considerations

- Need to revisit `"Multiple Nuanced Graphs found in <dir>"` case, which no longer applies
- Probably need more actionable error message when graph can't be found in current directory

ref: https://github.com/nuanced-dev/nuanced/issues/72