### PR TITLE
call_graph.generate analyzes packages and modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "jarviscg==0.1.0rc5",
+    "jarviscg",
     "setuptools>=75.3.0",
     "typer>=0.15.1",
 ]
@@ -31,3 +31,6 @@ dev = [
 pythonpath = [
     "."
 ]
+
+[tool.uv.sources]
+jarviscg = { path = "../jarviscg" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "jarviscg",
+    "jarviscg==0.1.0rc6",
     "setuptools>=75.3.0",
     "typer>=0.15.1",
 ]
@@ -31,6 +31,3 @@ dev = [
 pythonpath = [
     "."
 ]
-
-[tool.uv.sources]
-jarviscg = { path = "../jarviscg" }

--- a/src/nuanced/lib/call_graph.py
+++ b/src/nuanced/lib/call_graph.py
@@ -38,8 +38,8 @@ def _generate_package_call_graph(*, file_paths=list[str], package_dir_path: str)
     )
     call_graph.analyze()
     graph_root = os.getcwd()
-    relpath = os.path.relpath(package_dir_path, graph_root)
-    formatter = formats.Nuanced(call_graph, relpath=relpath)
+    scope_prefix = os.path.relpath(package_dir_path, graph_root).replace("/", ".")
+    formatter = formats.Nuanced(call_graph, scope_prefix=scope_prefix)
     return formatter.generate()
 
 def _generate_modules_call_graph(*, file_paths=list[str]) -> None:

--- a/src/nuanced/lib/call_graph.py
+++ b/src/nuanced/lib/call_graph.py
@@ -17,7 +17,7 @@ def generate(entry_points: list, **kwargs) -> dict:
             file_paths=file_paths,
             package_dir_path=dir_path
         )
-        graph |= package_call_graph
+        graph.update(package_call_graph)
 
     for file_paths in modules_by_dir.values():
         modules_call_graph = _generate_modules_call_graph(file_paths=file_paths)

--- a/src/nuanced/lib/call_graph.py
+++ b/src/nuanced/lib/call_graph.py
@@ -1,32 +1,56 @@
 from jarviscg import formats
 from jarviscg.core import CallGraphGenerator
+from nuanced.lib.utils import grouped_by_directory, grouped_by_package
+import os
 
 
 BUILTIN_FUNCTION_PREFIX = "<builtin>"
 
 def generate(entry_points: list, **kwargs) -> dict:
-    args = {
-        "package": None,
-        "decy": False,
-        "precision": False,
-        "moduleEntry": None,
-    }
-    package_path = kwargs.get("package_path", None)
+    graph = {}
+    files_by_package_dir = grouped_by_package(entry_points)
+    flattened = set([item for sublist in files_by_package_dir.values() for item in sublist])
+    modules_by_dir = grouped_by_directory(list(set(entry_points).difference(flattened)))
 
-    if package_path:
-        package_path_parts = package_path.split("/")
-        package_parent_path = "/".join(package_path_parts[0:-1])
-        args["package"] = package_parent_path
+    for dir_path, file_paths in files_by_package_dir.items():
+        package_call_graph = _generate_package_call_graph(
+            file_paths=file_paths,
+            package_dir_path=dir_path
+        )
+        graph |= package_call_graph
 
+    for file_paths in modules_by_dir.values():
+        modules_call_graph = _generate_modules_call_graph(file_paths=file_paths)
+        modules_call_graph.update(graph)
+        graph = modules_call_graph
+
+    return graph
+
+def _generate_package_call_graph(*, file_paths=list[str], package_dir_path: str) -> None:
+    package_path_parts = package_dir_path.split("/")
+    package_parent_path = "/".join(package_path_parts[0:-1])
     call_graph = CallGraphGenerator(
-        entry_points,
-        args["package"],
-        decy=args["decy"],
-        precision=args["precision"],
-        moduleEntry=args["moduleEntry"],
+        file_paths,
+        package_parent_path,
+        decy=None,
+        precision=None,
+        moduleEntry=None,
+    )
+    call_graph.analyze()
+    graph_root = os.getcwd()
+    relpath = os.path.relpath(package_dir_path, graph_root)
+    formatter = formats.Nuanced(call_graph, relpath=relpath)
+    return formatter.generate()
+
+def _generate_modules_call_graph(*, file_paths=list[str]) -> None:
+    call_graph = CallGraphGenerator(
+        file_paths,
+        os.getcwd(),
+        decy=None,
+        precision=None,
+        moduleEntry=None,
     )
     call_graph.analyze()
 
     formatter = formats.Nuanced(call_graph)
-    call_graph_dict = formatter.generate()
-    return call_graph_dict
+    return formatter.generate()

--- a/src/nuanced/lib/call_graph.py
+++ b/src/nuanced/lib/call_graph.py
@@ -26,7 +26,7 @@ def generate(entry_points: list, **kwargs) -> dict:
 
     return graph
 
-def _generate_package_call_graph(*, file_paths=list[str], package_dir_path: str) -> None:
+def _generate_package_call_graph(*, file_paths=list[str], package_dir_path: str) -> dict:
     package_path_parts = package_dir_path.split("/")
     package_parent_path = "/".join(package_path_parts[0:-1])
     call_graph = CallGraphGenerator(
@@ -42,7 +42,7 @@ def _generate_package_call_graph(*, file_paths=list[str], package_dir_path: str)
     formatter = formats.Nuanced(call_graph, scope_prefix=scope_prefix)
     return formatter.generate()
 
-def _generate_modules_call_graph(*, file_paths=list[str]) -> None:
+def _generate_modules_call_graph(*, file_paths=list[str]) -> dict:
     call_graph = CallGraphGenerator(
         file_paths,
         os.getcwd(),

--- a/src/nuanced/lib/utils.py
+++ b/src/nuanced/lib/utils.py
@@ -35,3 +35,37 @@ def with_timeout(target, args, kwargs, timeout):
     process.join()
 
     return WithTimeoutResult(errors=errors, value=value)
+
+def grouped_by_package(file_paths: list[str]):
+    packages = {}
+    package_roots = set()
+
+    for path in file_paths:
+        if path.endswith("__init__.py"):
+            package_root = "/".join(path.split("/")[:-1])
+            is_nested_package = any(package_root.startswith(p) for p in package_roots)
+            if not is_nested_package:
+                package_roots.add(package_root)
+
+    for package_root in package_roots:
+        package_files = []
+        for path in file_paths:
+            if path.startswith(package_root + "/"):
+                package_files.append(path)
+
+        if package_files:
+            packages[package_root] = package_files
+
+    return packages
+
+def grouped_by_directory(file_paths: list[str]):
+    directory_groups = {}
+
+    for path in file_paths:
+        directory = "/".join(path.split("/")[:-1])
+
+        if directory not in directory_groups:
+            directory_groups[directory] = []
+        directory_groups[directory].append(path)
+
+    return directory_groups

--- a/src/nuanced/lib/utils.py
+++ b/src/nuanced/lib/utils.py
@@ -42,7 +42,7 @@ def grouped_by_package(file_paths: list[str]):
 
     for path in file_paths:
         if path.endswith("__init__.py"):
-            package_root = "/".join(path.split("/")[:-1])
+            package_root = path.rsplit("/", 1)[0]
             is_nested_package = any(package_root.startswith(p) for p in package_roots)
             if not is_nested_package:
                 package_roots.add(package_root)
@@ -62,7 +62,7 @@ def grouped_by_directory(file_paths: list[str]):
     directory_groups = {}
 
     for path in file_paths:
-        directory = "/".join(path.split("/")[:-1])
+        directory = path.rsplit("/", 1)[0]
 
         if directory not in directory_groups:
             directory_groups[directory] = []

--- a/src/nuanced/lib/utils.py
+++ b/src/nuanced/lib/utils.py
@@ -40,21 +40,21 @@ def grouped_by_package(file_paths: list[str]):
     packages = {}
     package_roots = set()
 
+    package_definition_file_paths = list(filter(lambda p: p.endswith("__init__.py"), file_paths))
+
+    for path in package_definition_file_paths:
+        package_root = path.rsplit("/", 1)[0]
+        is_nested_package = any(package_root.startswith(p) for p in package_roots)
+        if not is_nested_package:
+            package_roots.add(package_root)
+
     for path in file_paths:
-        if path.endswith("__init__.py"):
-            package_root = path.rsplit("/", 1)[0]
-            is_nested_package = any(package_root.startswith(p) for p in package_roots)
-            if not is_nested_package:
-                package_roots.add(package_root)
-
-    for package_root in package_roots:
-        package_files = []
-        for path in file_paths:
+        for package_root in package_roots:
             if path.startswith(package_root + "/"):
-                package_files.append(path)
-
-        if package_files:
-            packages[package_root] = package_files
+                if package_root not in packages:
+                    packages[package_root] = []
+                packages[package_root].append(path)
+                break
 
     return packages
 

--- a/tests/module_fixtures/nested/nested_mod.py
+++ b/tests/module_fixtures/nested/nested_mod.py
@@ -1,0 +1,4 @@
+from ..module_two import mod_two_fn_one
+
+def nested_mod_fn_one():
+    mod_two_fn_one()

--- a/tests/nuanced/call_graph_test.py
+++ b/tests/nuanced/call_graph_test.py
@@ -6,6 +6,73 @@ from nuanced.lib import call_graph
 from tests.package_fixtures.fixture_class import FixtureClass
 
 
+def test_generate_with_nested_package_returns_call_graph_dict() -> None:
+    entry_points = [
+        "tests/package_fixtures/nested_package/__init__.py",
+        "tests/package_fixtures/nested_package/mod_one.py",
+    ]
+    expected = {
+        "tests.package_fixtures.nested_package": {
+          "filepath": os.path.abspath("tests/package_fixtures/nested_package/__init__.py"),
+          "callees": [],
+          "lineno": 0,
+          "end_lineno": 0
+        },
+        "tests.package_fixtures.nested_package.mod_one": {
+          "filepath": os.path.abspath("tests/package_fixtures/nested_package/mod_one.py"),
+          "callees": [],
+          "lineno": 1,
+          "end_lineno": 4
+        },
+        "tests.package_fixtures.nested_package.mod_one.nested_package_mod_one_fn_one": {
+          "filepath": os.path.abspath("tests/package_fixtures/nested_package/mod_one.py"),
+          "callees": [
+            "tests.module_fixtures.module_two.mod_two_fn_one"
+          ],
+          "lineno": 3,
+          "end_lineno": 4
+        }
+    }
+
+    call_graph_dict = call_graph.generate(entry_points)
+
+    diff = DeepDiff(expected, call_graph_dict, ignore_order=True)
+    assert diff == {}
+
+def test_generate_with_nested_module_returns_call_graph_dict() -> None:
+    entry_points = ["tests/module_fixtures/nested/nested_mod.py"]
+    expected = {
+      "tests.module_fixtures.module_two": {
+        "filepath": os.path.abspath("tests/module_fixtures/module_two.py"),
+        "callees": [],
+        "lineno": 1,
+        "end_lineno": 2,
+      },
+      "tests.module_fixtures.module_two.mod_two_fn_one": {
+        "filepath": os.path.abspath("tests/module_fixtures/module_two.py"),
+        "callees": [],
+        "lineno": 1,
+        "end_lineno": 2,
+      },
+      "tests.module_fixtures.nested.nested_mod": {
+        "filepath": os.path.abspath("tests/module_fixtures/nested/nested_mod.py"),
+        "callees": ["tests.module_fixtures.module_two"],
+        "lineno": 1,
+        "end_lineno": 4
+      },
+      "tests.module_fixtures.nested.nested_mod.nested_mod_fn_one": {
+        "filepath": os.path.abspath("tests/module_fixtures/nested/nested_mod.py"),
+        "callees": ["tests.module_fixtures.module_two.mod_two_fn_one"],
+        "lineno": 3,
+        "end_lineno": 4
+      },
+    }
+
+    call_graph_dict = call_graph.generate(entry_points)
+
+    diff = DeepDiff(expected, call_graph_dict, ignore_order=True)
+    assert diff == {}
+
 def test_generate_with_package_files_returns_call_graph_dict() -> None:
     entry_points = [
         "tests/package_fixtures/scripts/script.py",
@@ -15,111 +82,110 @@ def test_generate_with_package_files_returns_call_graph_dict() -> None:
         "tests/package_fixtures/nested_package/__init__.py",
         "tests/package_fixtures/nested_package/mod_one.py",
     ]
-    package_path = "tests/package_fixtures"
     expected = {
-        "package_fixtures.nested_modules.nested_fixture_class": {
+        "tests.package_fixtures.nested_modules.nested_fixture_class": {
           "filepath": os.path.abspath("tests/package_fixtures/nested_modules/nested_fixture_class.py"),
           "callees": [
-            "package_fixtures.nested_modules.nested_fixture_class.NestedFixtureClass"
+            "tests.package_fixtures.nested_modules.nested_fixture_class.NestedFixtureClass"
           ],
           "lineno": 1,
           "end_lineno": 3
         },
-        "package_fixtures.nested_modules.nested_fixture_class.NestedFixtureClass.hello_world": {
+        "tests.package_fixtures.nested_modules.nested_fixture_class.NestedFixtureClass.hello_world": {
           "filepath": os.path.abspath("tests/package_fixtures/nested_modules/nested_fixture_class.py"),
           "callees": [],
           "lineno": 2,
           "end_lineno": 3
         },
-        "package_fixtures.scripts.script": {
+        "tests.package_fixtures.scripts.script": {
           "filepath": os.path.abspath("tests/package_fixtures/scripts/script.py"),
           "callees": [
-            "package_fixtures.fixture_class",
-            "package_fixtures.scripts.script.run"
+            "tests.package_fixtures.fixture_class",
+            "tests.package_fixtures.scripts.script.run"
           ],
           "lineno": 1,
           "end_lineno": 9
         },
-        "package_fixtures.scripts.script.run": {
+        "tests.package_fixtures.scripts.script.run": {
           "filepath": os.path.abspath("tests/package_fixtures/scripts/script.py"),
           "callees": [
-            "package_fixtures.fixture_class.helper_function",
-            "package_fixtures.fixture_class.FixtureClass.bar",
-            "package_fixtures.fixture_class.FixtureClass.__init__"
+            "tests.package_fixtures.fixture_class.helper_function",
+            "tests.package_fixtures.fixture_class.FixtureClass.bar",
+            "tests.package_fixtures.fixture_class.FixtureClass.__init__"
           ],
           "lineno": 4,
           "end_lineno": 7
         },
-        "package_fixtures.fixture_class": {
+        "tests.package_fixtures.fixture_class": {
           "filepath": os.path.abspath("tests/package_fixtures/fixture_class.py"),
           "callees": [
-            "package_fixtures.nested_modules.nested_fixture_class",
-            "package_fixtures.fixture_class.FixtureClass",
-            "package_fixtures.nested_package.mod_one",
+            "tests.package_fixtures.nested_modules.nested_fixture_class",
+            "tests.package_fixtures.fixture_class.FixtureClass",
+            "tests.package_fixtures.nested_package.mod_one",
           ],
           "lineno": 1,
           "end_lineno": 20
         },
-        "package_fixtures.fixture_class.helper_function": {
+        "tests.package_fixtures.fixture_class.helper_function": {
           "filepath": os.path.abspath("tests/package_fixtures/fixture_class.py"),
           "callees": [
-            "package_fixtures.nested_modules.nested_fixture_class.NestedFixtureClass.hello_world"
+            "tests.package_fixtures.nested_modules.nested_fixture_class.NestedFixtureClass.hello_world"
           ],
           "lineno": 6,
           "end_lineno": 9
         },
-        "package_fixtures.fixture_class.FixtureClass.__init__": {
+        "tests.package_fixtures.fixture_class.FixtureClass.__init__": {
           "filepath": os.path.abspath("tests/package_fixtures/fixture_class.py"),
           "callees": [],
           "lineno": 12,
           "end_lineno": 13
         },
-        "package_fixtures.fixture_class.FixtureClass.foo": {
+        "tests.package_fixtures.fixture_class.FixtureClass.foo": {
           "filepath": os.path.abspath("tests/package_fixtures/fixture_class.py"),
           "callees": [
             "datetime.datetime.now",
-            "package_fixtures.nested_package.mod_one.nested_package_mod_one_fn_one",
+            "tests.package_fixtures.nested_package.mod_one.nested_package_mod_one_fn_one",
           ],
           "lineno": 15,
           "end_lineno": 17
         },
-        "package_fixtures.fixture_class.FixtureClass.bar": {
+        "tests.package_fixtures.fixture_class.FixtureClass.bar": {
           "filepath": os.path.abspath("tests/package_fixtures/fixture_class.py"),
           "callees": [
-            "package_fixtures.fixture_class.FixtureClass.foo"
+            "tests.package_fixtures.fixture_class.FixtureClass.foo"
           ],
           "lineno": 19,
           "end_lineno": 20
         },
-        "package_fixtures": {
+        "tests.package_fixtures": {
           "filepath": os.path.abspath("tests/package_fixtures/__init__.py"),
           "callees": [],
           "lineno": 0,
           "end_lineno": 0
         },
-        "package_fixtures.nested_package": {
+        "tests.package_fixtures.nested_package": {
           "filepath": os.path.abspath("tests/package_fixtures/nested_package/__init__.py"),
           "callees": [],
           "lineno": 0,
           "end_lineno": 0
         },
-        "package_fixtures.nested_package.mod_one": {
+        "tests.package_fixtures.nested_package.mod_one": {
           "filepath": os.path.abspath("tests/package_fixtures/nested_package/mod_one.py"),
           "callees": [],
           "lineno": 1,
-          "end_lineno": 2
+          "end_lineno": 4
         },
-        "package_fixtures.nested_package.mod_one.nested_package_mod_one_fn_one": {
+        "tests.package_fixtures.nested_package.mod_one.nested_package_mod_one_fn_one": {
           "filepath": os.path.abspath("tests/package_fixtures/nested_package/mod_one.py"),
-          "callees": [],
-          "lineno": 1,
-          "end_lineno": 2
-        }
+          "callees": ["tests.module_fixtures.module_two.mod_two_fn_one"],
+          "lineno": 3,
+          "end_lineno": 4
+        },
       }
 
-    call_graph_dict = call_graph.generate(entry_points, package_path=package_path)
+    call_graph_dict = call_graph.generate(entry_points)
 
-    diff = DeepDiff(call_graph_dict, expected, ignore_order=True)
+    diff = DeepDiff(expected, call_graph_dict, ignore_order=True)
     assert diff == {}
 
 def test_generate_with_module_files_returns_call_graph_dict() -> None:
@@ -128,50 +194,103 @@ def test_generate_with_module_files_returns_call_graph_dict() -> None:
         "tests/module_fixtures/module_two.py",
     ]
     expected = {
-        "module_fixtures.module_one": {
-          "filepath": os.path.abspath("tests/module_fixtures/module_one.py"),
-          "callees": ["module_fixtures.module_two"],
-          "lineno": 1,
-          "end_lineno": 8
-        },
-        "module_fixtures.module_one.mod_one_fn_one": {
-          "filepath": os.path.abspath("tests/module_fixtures/module_one.py"),
-          "callees": [
-            "tests.package_fixtures.fixture_class.FixtureClass",
-            "module_fixtures.module_two.mod_two_fn_one"
-          ],
-          "lineno": 4,
-          "end_lineno": 8
-        },
-        "module_fixtures.module_two": {
-          "filepath": os.path.abspath("tests/module_fixtures/module_two.py"),
-          "callees": [],
-          "lineno": 1,
-          "end_lineno": 2
-        },
-        "module_fixtures.module_two.mod_two_fn_one": {
-          "filepath": os.path.abspath("tests/module_fixtures/module_two.py"),
-          "callees": [],
-          "lineno": 1,
-          "end_lineno": 2
-        },
+      "tests.module_fixtures.module_one": {
+        "filepath": "/Users/laila/Source/nuanced/nuanced/tests/module_fixtures/module_one.py",
+        "callees": [
+          "tests.package_fixtures.fixture_class",
+          "tests.module_fixtures.module_two"
+        ],
+        "lineno": 1,
+        "end_lineno": 8
+      },
+      "tests.module_fixtures.module_one.mod_one_fn_one": {
+        "filepath": "/Users/laila/Source/nuanced/nuanced/tests/module_fixtures/module_one.py",
+        "callees": [
+          "module_two.mod_two_fn_one",
+          "tests.module_fixtures.module_two.mod_two_fn_one",
+          "tests.package_fixtures.fixture_class.FixtureClass.foo",
+          "tests.package_fixtures.fixture_class.FixtureClass.__init__"
+        ],
+        "lineno": 4,
+        "end_lineno": 8
+      },
+      "tests.module_fixtures.module_two": {
+        "filepath": "/Users/laila/Source/nuanced/nuanced/tests/module_fixtures/module_two.py",
+        "callees": [],
+        "lineno": 1,
+        "end_lineno": 2
+      },
+      "tests.module_fixtures.module_two.mod_two_fn_one": {
+        "filepath": "/Users/laila/Source/nuanced/nuanced/tests/module_fixtures/module_two.py",
+        "callees": [],
+        "lineno": 1,
+        "end_lineno": 2
+      },
+      "tests.package_fixtures.fixture_class": {
+        "filepath": "/Users/laila/Source/nuanced/nuanced/tests/package_fixtures/fixture_class.py",
+        "callees": [
+          "tests.package_fixtures.fixture_class.FixtureClass",
+          "tests.package_fixtures.nested_package.mod_one"
+        ],
+        "lineno": 1,
+        "end_lineno": 20
+      },
+      "tests.package_fixtures.fixture_class.helper_function": {
+        "filepath": "/Users/laila/Source/nuanced/nuanced/tests/package_fixtures/fixture_class.py",
+        "callees": [],
+        "lineno": 6,
+        "end_lineno": 9
+      },
+      "tests.package_fixtures.fixture_class.FixtureClass.__init__": {
+        "filepath": "/Users/laila/Source/nuanced/nuanced/tests/package_fixtures/fixture_class.py",
+        "callees": [],
+        "lineno": 12,
+        "end_lineno": 13
+      },
+      "tests.package_fixtures.fixture_class.FixtureClass.foo": {
+        "filepath": "/Users/laila/Source/nuanced/nuanced/tests/package_fixtures/fixture_class.py",
+        "callees": [
+          "tests.package_fixtures.nested_package.mod_one.nested_package_mod_one_fn_one",
+          "datetime.datetime.now"
+        ],
+        "lineno": 15,
+        "end_lineno": 17
+      },
+      "tests.package_fixtures.fixture_class.FixtureClass.bar": {
+        "filepath": "/Users/laila/Source/nuanced/nuanced/tests/package_fixtures/fixture_class.py",
+        "callees": [],
+        "lineno": 19,
+        "end_lineno": 20
+      },
+      "tests.package_fixtures.nested_package.mod_one": {
+        "filepath": "/Users/laila/Source/nuanced/nuanced/tests/package_fixtures/nested_package/mod_one.py",
+        "callees": ["tests.module_fixtures.module_two"],
+        "lineno": 1,
+        "end_lineno": 4
+      },
+      "tests.package_fixtures.nested_package.mod_one.nested_package_mod_one_fn_one": {
+        "filepath": "/Users/laila/Source/nuanced/nuanced/tests/package_fixtures/nested_package/mod_one.py",
+        "callees": ["tests.module_fixtures.module_two.mod_two_fn_one"],
+        "lineno": 3,
+        "end_lineno": 4
+      }
     }
 
-    call_graph_dict = call_graph.generate(entry_points, package_path="tests/module_fixtures")
+    call_graph_dict = call_graph.generate(entry_points)
 
-    diff = DeepDiff(call_graph_dict, expected, ignore_order=True)
+    diff = DeepDiff(expected, call_graph_dict, ignore_order=True)
     assert diff == {}
 
 def test_generate_defaults_with_packages_and_modules_returns_call_graph_dict() -> None:
     entry_points = [
-        'tests/package_fixtures/fixture_class.py',
-        'tests/package_fixtures/__init__.py',
-        'tests/package_fixtures/scripts/script.py',
-        'tests/package_fixtures/nested_package/__init__.py',
-        'tests/package_fixtures/nested_package/mod_one.py',
-        'tests/package_fixtures/nested_modules/nested_fixture_class.py',
-        'tests/module_fixtures/module_one.py',
-        'tests/module_fixtures/module_two.py',
+        "tests/package_fixtures/fixture_class.py",
+        "tests/package_fixtures/__init__.py",
+        "tests/package_fixtures/scripts/script.py",
+        "tests/package_fixtures/nested_package/__init__.py",
+        "tests/package_fixtures/nested_package/mod_one.py",
+        "tests/package_fixtures/nested_modules/nested_fixture_class.py",
+        "tests/module_fixtures/module_one.py",
+        "tests/module_fixtures/module_two.py",
     ]
     expected = {
         "tests.package_fixtures.nested_modules.nested_fixture_class": {
@@ -191,7 +310,8 @@ def test_generate_defaults_with_packages_and_modules_returns_call_graph_dict() -
         "tests.package_fixtures.scripts.script": {
           "filepath": os.path.abspath("tests/package_fixtures/scripts/script.py"),
           "callees": [
-            "tests.package_fixtures.scripts.script.run"
+            "tests.package_fixtures.scripts.script.run",
+            "tests.package_fixtures.fixture_class"
           ],
           "lineno": 1,
           "end_lineno": 9
@@ -200,14 +320,18 @@ def test_generate_defaults_with_packages_and_modules_returns_call_graph_dict() -
           "filepath": os.path.abspath("tests/package_fixtures/scripts/script.py"),
           "callees": [
             "tests.package_fixtures.fixture_class.helper_function",
-            "fixture_class.FixtureClass"
+            "tests.package_fixtures.fixture_class.FixtureClass.__init__",
+            "tests.package_fixtures.fixture_class.FixtureClass.bar"
           ],
           "lineno": 4,
           "end_lineno": 7
         },
         "tests.module_fixtures.module_one": {
           "filepath": os.path.abspath("tests/module_fixtures/module_one.py"),
-          "callees": [],
+          "callees": [
+            "tests.module_fixtures.module_two",
+            "tests.package_fixtures.fixture_class"
+          ],
           "lineno": 1,
           "end_lineno": 8
         },
@@ -215,8 +339,10 @@ def test_generate_defaults_with_packages_and_modules_returns_call_graph_dict() -
           "filepath": os.path.abspath("tests/module_fixtures/module_one.py"),
           "callees": [
             "tests.package_fixtures.fixture_class.FixtureClass.foo",
+            "tests.package_fixtures.fixture_class.FixtureClass.__init__",
+            "tests.package_fixtures.fixture_class.FixtureClass.__init__",
+            "tests.module_fixtures.module_two.mod_two_fn_one",
             "module_two.mod_two_fn_one",
-            "tests.package_fixtures.fixture_class.FixtureClass.__init__"
           ],
           "lineno": 4,
           "end_lineno": 8
@@ -242,7 +368,9 @@ def test_generate_defaults_with_packages_and_modules_returns_call_graph_dict() -
         "tests.package_fixtures.fixture_class": {
           "filepath": os.path.abspath("tests/package_fixtures/fixture_class.py"),
           "callees": [
-            "tests.package_fixtures.fixture_class.FixtureClass"
+            "tests.package_fixtures.nested_package.mod_one",
+            "tests.package_fixtures.fixture_class.FixtureClass",
+            "tests.package_fixtures.nested_modules.nested_fixture_class"
           ],
           "lineno": 1,
           "end_lineno": 20
@@ -250,7 +378,7 @@ def test_generate_defaults_with_packages_and_modules_returns_call_graph_dict() -
         "tests.package_fixtures.fixture_class.helper_function": {
           "filepath": os.path.abspath("tests/package_fixtures/fixture_class.py"),
           "callees": [
-            "nested_modules.nested_fixture_class.NestedFixtureClass"
+            "tests.package_fixtures.nested_modules.nested_fixture_class.NestedFixtureClass.hello_world",
           ],
           "lineno": 6,
           "end_lineno": 9
@@ -288,167 +416,17 @@ def test_generate_defaults_with_packages_and_modules_returns_call_graph_dict() -
           "filepath": os.path.abspath("tests/package_fixtures/nested_package/mod_one.py"),
           "callees": [],
           "lineno": 1,
-          "end_lineno": 2
+          "end_lineno": 4
         },
         "tests.package_fixtures.nested_package.mod_one.nested_package_mod_one_fn_one": {
           "filepath": os.path.abspath("tests/package_fixtures/nested_package/mod_one.py"),
-          "callees": [],
-          "lineno": 1,
-          "end_lineno": 2
+          "callees": ["tests.module_fixtures.module_two.mod_two_fn_one"],
+          "lineno": 3,
+          "end_lineno": 4
         }
     }
 
     call_graph_dict = call_graph.generate(entry_points)
-
-    diff = DeepDiff(expected, call_graph_dict, ignore_order=True)
-    assert diff == {}
-
-def test_generate_with_packages_and_modules_returns_call_graph_dict() -> None:
-    entry_points = [
-        "tests/package_fixtures/fixture_class.py",
-        "tests/package_fixtures/__init__.py",
-        "tests/package_fixtures/scripts/script.py",
-        "tests/package_fixtures/nested_modules/nested_fixture_class.py",
-        "tests/module_fixtures/module_one.py",
-        "tests/module_fixtures/module_two.py",
-        "tests/package_fixtures/nested_package/__init__.py",
-        "tests/package_fixtures/nested_package/mod_one.py"
-    ]
-    package_path = "tests/package_fixtures"
-    expected = {
-        "package_fixtures.nested_modules.nested_fixture_class": {
-          "filepath": os.path.abspath("tests/package_fixtures/nested_modules/nested_fixture_class.py"),
-          "callees": [
-            "package_fixtures.nested_modules.nested_fixture_class.NestedFixtureClass"
-          ],
-          "lineno": 1,
-          "end_lineno": 3
-        },
-        "package_fixtures.nested_modules.nested_fixture_class.NestedFixtureClass.hello_world": {
-          "filepath": os.path.abspath("tests/package_fixtures/nested_modules/nested_fixture_class.py"),
-          "callees": [],
-          "lineno": 2,
-          "end_lineno": 3
-        },
-        "package_fixtures.scripts.script": {
-          "filepath": os.path.abspath("tests/package_fixtures/scripts/script.py"),
-          "callees": [
-            "package_fixtures.fixture_class",
-            "package_fixtures.scripts.script.run"
-          ],
-          "lineno": 1,
-          "end_lineno": 9
-        },
-        "package_fixtures.scripts.script.run": {
-          "filepath": os.path.abspath("tests/package_fixtures/scripts/script.py"),
-          "callees": [
-            "package_fixtures.fixture_class.FixtureClass.bar",
-            "package_fixtures.fixture_class.helper_function",
-            "package_fixtures.fixture_class.FixtureClass.__init__"
-          ],
-          "lineno": 4,
-          "end_lineno": 7
-        },
-        "package_fixtures.fixture_class": {
-          "filepath": os.path.abspath("tests/package_fixtures/fixture_class.py"),
-          "callees": [
-            "package_fixtures.nested_modules.nested_fixture_class",
-            "package_fixtures.nested_package.mod_one",
-            "package_fixtures.fixture_class.FixtureClass"
-          ],
-          "lineno": 1,
-          "end_lineno": 20
-        },
-        "package_fixtures.fixture_class.helper_function": {
-          "filepath": os.path.abspath("tests/package_fixtures/fixture_class.py"),
-          "callees": [
-            "package_fixtures.nested_modules.nested_fixture_class.NestedFixtureClass.hello_world"
-          ],
-          "lineno": 6,
-          "end_lineno": 9
-        },
-        "package_fixtures.fixture_class.FixtureClass.__init__": {
-          "filepath": os.path.abspath("tests/package_fixtures/fixture_class.py"),
-          "callees": [],
-          "lineno": 12,
-          "end_lineno": 13
-        },
-        "package_fixtures.fixture_class.FixtureClass.foo": {
-          "filepath": os.path.abspath("tests/package_fixtures/fixture_class.py"),
-          "callees": [
-            "datetime.datetime.now",
-            "package_fixtures.nested_package.mod_one.nested_package_mod_one_fn_one",
-          ],
-          "lineno": 15,
-          "end_lineno": 17
-        },
-        "package_fixtures.fixture_class.FixtureClass.bar": {
-          "filepath": os.path.abspath("tests/package_fixtures/fixture_class.py"),
-          "callees": [
-            "package_fixtures.fixture_class.FixtureClass.foo"
-          ],
-          "lineno": 19,
-          "end_lineno": 20
-        },
-        "module_fixtures.module_one": {
-          "filepath": os.path.abspath("tests/module_fixtures/module_one.py"),
-          "callees": [
-            "package_fixtures.fixture_class",
-            "module_fixtures.module_two"
-          ],
-          "lineno": 1,
-          "end_lineno": 8
-        },
-        "module_fixtures.module_one.mod_one_fn_one": {
-          "filepath": os.path.abspath("tests/module_fixtures/module_one.py"),
-          "callees": [
-            "module_fixtures.module_two.mod_two_fn_one",
-            "module_two.mod_two_fn_one",
-            "package_fixtures.fixture_class.FixtureClass.foo",
-            "package_fixtures.fixture_class.FixtureClass.__init__"
-          ],
-          "lineno": 4,
-          "end_lineno": 8
-        },
-        "module_fixtures.module_two": {
-          "filepath": os.path.abspath("tests/module_fixtures/module_two.py"),
-          "callees": [],
-          "lineno": 1,
-          "end_lineno": 2
-        },
-        "module_fixtures.module_two.mod_two_fn_one": {
-          "filepath": os.path.abspath("tests/module_fixtures/module_two.py"),
-          "callees": [],
-          "lineno": 1,
-          "end_lineno": 2
-        },
-        "package_fixtures": {
-          "filepath": os.path.abspath("tests/package_fixtures/__init__.py"),
-          "callees": [],
-          "lineno": 0,
-          "end_lineno": 0
-        },
-        "package_fixtures.nested_package": {
-          "filepath": os.path.abspath("tests/package_fixtures/nested_package/__init__.py"),
-          "callees": [],
-          "lineno": 0,
-          "end_lineno": 0
-        },
-        "package_fixtures.nested_package.mod_one": {
-          "filepath": os.path.abspath("tests/package_fixtures/nested_package/mod_one.py"),
-          "callees": [],
-          "lineno": 1,
-          "end_lineno": 2
-        },
-        "package_fixtures.nested_package.mod_one.nested_package_mod_one_fn_one": {
-          "filepath": os.path.abspath("tests/package_fixtures/nested_package/mod_one.py"),
-          "callees": [],
-          "lineno": 1,
-          "end_lineno": 2
-        }
-    }
-
-    call_graph_dict = call_graph.generate(entry_points, package_path=package_path)
 
     diff = DeepDiff(expected, call_graph_dict, ignore_order=True)
     assert diff == {}

--- a/tests/nuanced/lib/utils_test.py
+++ b/tests/nuanced/lib/utils_test.py
@@ -1,0 +1,66 @@
+import pytest
+from nuanced.lib.utils import grouped_by_package, grouped_by_directory
+from deepdiff import DeepDiff
+
+def test_grouped_by_package() -> None:
+    file_paths = [
+        "tests/package_fixtures/fixture_class.py",
+        "tests/package_fixtures/__init__.py",
+        "tests/package_fixtures/scripts/script.py",
+        "tests/package_fixtures/nested_modules/nested_fixture_class.py",
+        "tests/module_fixtures/module_one.py",
+        "tests/module_fixtures/module_two.py",
+        "tests/package_fixtures/nested_package/__init__.py",
+        "tests/package_fixtures/nested_package/mod_one.py",
+        "foo/__init__.py",
+        "foo/bar.py",
+    ]
+    expected_packages = {
+        "tests/package_fixtures": [
+            "tests/package_fixtures/fixture_class.py",
+            "tests/package_fixtures/__init__.py",
+            "tests/package_fixtures/scripts/script.py",
+            "tests/package_fixtures/nested_modules/nested_fixture_class.py",
+            "tests/package_fixtures/nested_package/__init__.py",
+            "tests/package_fixtures/nested_package/mod_one.py"
+        ],
+        "foo": ["foo/__init__.py", "foo/bar.py"],
+    }
+
+    groups = grouped_by_package(file_paths)
+
+    diff = DeepDiff(expected_packages, groups, ignore_order=True)
+    assert diff == {}
+
+def test_grouped_by_directory() -> None:
+    file_paths = [
+        "tests/package_fixtures/fixture_class.py",
+        "tests/package_fixtures/__init__.py",
+        "tests/package_fixtures/scripts/script.py",
+        "tests/package_fixtures/nested_modules/nested_fixture_class.py",
+        "tests/module_fixtures/module_one.py",
+        "tests/module_fixtures/module_two.py",
+        "tests/package_fixtures/nested_package/__init__.py",
+        "tests/package_fixtures/nested_package/mod_one.py"
+    ]
+    expected = {
+        "tests/package_fixtures": [
+            "tests/package_fixtures/fixture_class.py",
+            "tests/package_fixtures/__init__.py",
+        ],
+        "tests/package_fixtures/scripts": ["tests/package_fixtures/scripts/script.py"],
+        "tests/package_fixtures/nested_modules": ["tests/package_fixtures/nested_modules/nested_fixture_class.py"],
+        "tests/package_fixtures/nested_package": [
+            "tests/package_fixtures/nested_package/__init__.py",
+            "tests/package_fixtures/nested_package/mod_one.py"
+        ],
+        "tests/module_fixtures": [
+            "tests/module_fixtures/module_one.py",
+            "tests/module_fixtures/module_two.py",
+        ]
+    }
+
+    groups = grouped_by_directory(file_paths)
+
+    diff = DeepDiff(expected, groups, ignore_order=True)
+    assert diff == {}

--- a/tests/package_fixtures/nested_package/mod_one.py
+++ b/tests/package_fixtures/nested_package/mod_one.py
@@ -1,2 +1,4 @@
+from tests.module_fixtures.module_two import mod_two_fn_one
+
 def nested_package_mod_one_fn_one():
-    return None
+    mod_two_fn_one()

--- a/uv.lock
+++ b/uv.lock
@@ -55,16 +55,16 @@ wheels = [
 
 [[package]]
 name = "jarviscg"
-version = "0.1.0rc5"
+version = "0.1.0rc6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deepdiff" },
     { name = "pytest" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/92/6943a61ddd491d7466144390bf2c0be2a1cad76e438ee26710d91ad510a9/jarviscg-0.1.0rc5.tar.gz", hash = "sha256:f7f2f0ca06f3052aef096b673cdc9988a5b673ff1e3ae813bc095ca21a4e4680", size = 54098729 }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/86/bb459ed041824576c13a092c4f7370c52d45167ab16c2fee38025fa2eb33/jarviscg-0.1.0rc6.tar.gz", hash = "sha256:47b50c59515ccd325c2a07a24244c547efc20bb7aa5687e7c69d26fa02b02929", size = 54253795 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/cd/60f2b116eccc22447edc34553225cb6894616be512580b89c8b9ea7bc02b/jarviscg-0.1.0rc5-py3-none-any.whl", hash = "sha256:587c757c5c7c440743019316c280eca0db029559074741ceb717c6cd16b4094e", size = 58020 },
+    { url = "https://files.pythonhosted.org/packages/c7/9c/38d5e062bee0a470ee1737d66008e25b3023a2901870f2984a3063f155d4/jarviscg-0.1.0rc6-py3-none-any.whl", hash = "sha256:92a40cb03bc47eada2170ea6656d389fc53a0d7dcb0e8ec74a72a2e529a85cc9", size = 49843 },
 ]
 
 [[package]]
@@ -107,7 +107,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "jarviscg", specifier = "==0.1.0rc5" },
+    { name = "jarviscg", specifier = "==0.1.0rc6" },
     { name = "setuptools", specifier = ">=75.3.0" },
     { name = "typer", specifier = ">=0.15.1" },
 ]


### PR DESCRIPTION
## Why?

We're moving to a strategy of generating and persisting one graph per codebase rather than one graph per Python package. This PR updates `call_graph.generate` to analyze the input file paths, apply different call graph generation strategies for packages and non-package modules and generate one big graph for all of them.

## How?

Summary of changes:
- Add utility function for grouping files by package
- Add utility function for grouping files by directory
- Update `call_graph.generate` tests to reflect desired outcomes
- Update `call_graph.generate` to group package files by package, group module files by directory, generate a call graph for each group and merge them all into one big call graph

## Considerations

- In the case where both packages and non-package modules are analyzed and there are collisions, preference is given to results from the package call graph generation strategy (L24 of call_graph.py). This is based on anecdata that the package results are more complete but could use more investigation.
- This approach to analyzing non-package modules seems to sometimes produce redundant `callees` entries for the same edge, e.g. a `callees` collection including both `module_two.mod_two_fn_one` and `tests.module_fixtures.module_two.mod_two_fn_one`, or non-unique `callees` entries. This is another thing that could use more investigation but in the meantime my attitude is that redundant information is better than incomplete information, and it is at least captured in the automated tests.
- This PR dependent on https://github.com/nuanced-dev/jarviscg/pull/37

## Testing

- Tests pass when I update nuanced to use my local version of jarviscg which includes the changes in https://github.com/nuanced-dev/jarviscg/pull/37
- The graph generated when I run `nuanced init .` locally from my `nuanced` directory seems right, although more inspection would be a good idea
- More QA is needed

ref: https://github.com/nuanced-dev/nuanced-operations/issues/239, https://github.com/nuanced-dev/nuanced/issues/72