### PR TITLE
Refactor graph test fixtures for readability

### DIFF
--- a/tests/nuanced/call_graph_test.py
+++ b/tests/nuanced/call_graph_test.py
@@ -243,4 +243,3 @@ def test_generate_output_includes_file_path_and_line_numbers() -> None:
 
     diff = DeepDiff(expected, call_graph_dict, ignore_order=True)
     assert diff == {}
-


### PR DESCRIPTION
## Why?

The test fixtures in call_graph_test.py test scenarios are really hard to read and reason about.

## How?

This PR reduces the verbosity of the test scenarios by updating assertions to verify only the expected edges in the graph, not all the properties (callees, filepath and line number properties).

It also adds one test that explicitly verifies the presence of filepath and line number properties.