### PR TITLE
Fix scope_prefix for top-level packages

### DIFF
--- a/src/nuanced/lib/call_graph.py
+++ b/src/nuanced/lib/call_graph.py
@@ -38,7 +38,12 @@ def _generate_package_call_graph(*, file_paths=list[str], package_dir_path: str)
     )
     call_graph.analyze()
     graph_root = os.getcwd()
-    scope_prefix = os.path.relpath(package_dir_path, graph_root).replace("/", ".")
+    path_from_cwd_to_package_dir = os.path.relpath(package_dir_path, graph_root)
+    scope_prefix = None
+
+    if path_from_cwd_to_package_dir.count(os.sep) > 0:
+        scope_prefix = path_from_cwd_to_package_dir.replace(os.sep, ".")
+
     formatter = formats.Nuanced(call_graph, scope_prefix=scope_prefix)
     return formatter.generate()
 

--- a/src/nuanced/lib/call_graph.py
+++ b/src/nuanced/lib/call_graph.py
@@ -27,8 +27,8 @@ def generate(entry_points: list, **kwargs) -> dict:
     return graph
 
 def _generate_package_call_graph(*, file_paths=list[str], package_dir_path: str) -> dict:
-    package_path_parts = package_dir_path.split("/")
-    package_parent_path = "/".join(package_path_parts[0:-1])
+    package_path_parts = package_dir_path.split(os.sep)
+    package_parent_path = os.sep.join(package_path_parts[0:-1])
     call_graph = CallGraphGenerator(
         file_paths,
         package_parent_path,

--- a/tests/nuanced/call_graph_test.py
+++ b/tests/nuanced/call_graph_test.py
@@ -5,6 +5,12 @@ import pytest
 from nuanced.lib import call_graph
 from tests.package_fixtures.fixture_class import FixtureClass
 
+def test_generate_with_top_level_package_sets_correct_scope_prefix() -> None:
+    entry_points = ["tests/__init__.py"]
+
+    call_graph_dict = call_graph.generate(entry_points)
+
+    assert "tests" in call_graph_dict
 
 def test_generate_with_nested_package_returns_call_graph_dict() -> None:
     entry_points = [


### PR DESCRIPTION
## Why?

I noticed while doing QA on the `project-analysis` branch that nodes in the graph generated for the nuanced/tests directory started with `.tests` instead of the expected `tests`.

## How?

Update `_generate_package_call_graph` to not set `scope_prefix` unless the package definition is nested more than one level below the current working directory.

ref: https://github.com/nuanced-dev/nuanced-operations/issues/239, https://github.com/nuanced-dev/nuanced/issues/72