### PR TITLE
Make initialization timeout configurable

### DIFF
--- a/src/nuanced/cli.py
+++ b/src/nuanced/cli.py
@@ -4,7 +4,8 @@ import typer
 from rich import print
 from rich.console import Console
 from nuanced import CodeGraph, __version__
-from nuanced.code_graph import CodeGraphResult
+from nuanced.code_graph import CodeGraphResult, DEFAULT_INIT_TIMEOUT_SECONDS
+from typing_extensions import Annotated, Optional
 
 app = typer.Typer()
 
@@ -46,11 +47,11 @@ def enrich(
 
 
 @app.command()
-def init(path: str) -> None:
+def init(path: str, timeout_seconds: Annotated[Optional[int], typer.Option("--timeout-seconds", "-t", metavar=f"{DEFAULT_INIT_TIMEOUT_SECONDS}", help="Timeout in seconds.")]=DEFAULT_INIT_TIMEOUT_SECONDS) -> None:
     err_console = Console(stderr=True)
     abspath = os.path.abspath(path)
     print(f"Initializing {abspath}")
-    result = CodeGraph.init(abspath)
+    result = CodeGraph.init(abspath, timeout_seconds=timeout_seconds)
 
     if len(result.errors) > 0:
         for error in result.errors:

--- a/src/nuanced/code_graph.py
+++ b/src/nuanced/code_graph.py
@@ -11,15 +11,15 @@ from nuanced.lib.utils import with_timeout
 CodeGraphResult = namedtuple("CodeGraphResult", ["errors", "code_graph"])
 EnrichmentResult = namedtuple("EnrichmentResult", ["errors", "result"])
 
+DEFAULT_INIT_TIMEOUT_SECONDS = 60
 
 class CodeGraph():
     ELIGIBLE_FILE_TYPE_PATTERN = "*.py"
-    INIT_TIMEOUT_SECONDS = 60
     NUANCED_DIRNAME = ".nuanced"
     NUANCED_GRAPH_FILENAME = "nuanced-graph.json"
 
     @classmethod
-    def init(cls, path: str) -> CodeGraphResult:
+    def init(cls, path: str, *, timeout_seconds: int=DEFAULT_INIT_TIMEOUT_SECONDS) -> CodeGraphResult:
         errors = []
         code_graph = None
         absolute_path_to_package = os.path.abspath(path)
@@ -47,7 +47,7 @@ class CodeGraph():
                     target=call_graph.generate,
                     args=(eligible_absolute_filepaths),
                     kwargs=({"package_path": absolute_path_to_package}),
-                    timeout=cls.INIT_TIMEOUT_SECONDS,
+                    timeout=timeout_seconds,
                 )
                 call_graph_dict = call_graph_result.value
 


### PR DESCRIPTION
## Why?

We anticipate that codebase analysis will generally be slower than package analysis. We want to make the initialization timeout configurable so users can increase the timeout threshold if they find that the default threshold of 60s is too low.

## How?

- Add `--timeout-seconds` option to `nuanced init` CLI command and update command to pass the value to `CodeGraph.init`
- Update `CodeGraph.init` to accept an optional `timeout_seconds` keyword arg
- Default timeout is still 60s

ref: https://github.com/nuanced-dev/nuanced-operations/issues/239, https://github.com/nuanced-dev/nuanced/issues/57, https://github.com/nuanced-dev/nuanced/issues/72