### PR TITLE
Revert "enrich command always loads graph from working directory"

### DIFF
--- a/tests/nuanced/cli_test.py
+++ b/tests/nuanced/cli_test.py
@@ -15,7 +15,7 @@ def test_version_displays_installed_version():
 
     assert result.stdout == f"nuanced {__version__}\n"
 
-def test_enrich_finds_relevant_graph_in_current_dir(mocker):
+def test_enrich_finds_relevant_graph_in_file_dir(mocker):
     graph = { "foo.bar": { "filepath": os.path.abspath("foo.py"), "callees": [] } }
     code_graph = CodeGraph(graph=graph)
     mocker.patch(
@@ -26,7 +26,27 @@ def test_enrich_finds_relevant_graph_in_current_dir(mocker):
 
     runner.invoke(app, ["enrich", "foo.py", "bar"])
 
-    load_spy.assert_called_with(directory=".")
+    load_spy.assert_called_with(directory="")
+
+def test_enrich_finds_relevant_graph_in_file_path_parent_dir(mocker):
+    file_path = "foo/bar/baz.py"
+    file_dir, _ = os.path.split(file_path)
+    top_dir = "foo"
+    top_dir_contents = (top_dir, [CodeGraph.NUANCED_DIRNAME, "bar"], ["__init__.py"])
+    stub_graph = {}
+    result_with_errors = CodeGraphResult(code_graph=None, errors=["Graph not found"])
+    valid_result = CodeGraphResult(code_graph=CodeGraph(stub_graph), errors=[])
+    mocker.patch("os.walk", lambda directory: [top_dir_contents])
+    mocker.patch(
+        "nuanced.cli.CodeGraph.load",
+        lambda directory: result_with_errors if directory == file_dir else valid_result
+    )
+    expected_calls = [mocker.call(directory=file_dir)]
+    load_spy = mocker.spy(CodeGraph, "load")
+
+    runner.invoke(app, ["enrich", file_path, "hello_world"])
+
+    load_spy.assert_has_calls(expected_calls)
 
 def test_enrich_finds_relevant_graph_in_file_path_scope(mocker):
     file_path = "../foo/bar/baz.py"


### PR DESCRIPTION
## Why?

https://github.com/nuanced-dev/nuanced/pull/84 was merged with the assumption that implementing codebase analysis meant we would be able to always generate one big graph for all packages and modules within the directory path passed to `init`. However, after QA and benchmarking it seems prudent to continue to support analysis of individual packages and directories. In the absence of a workflow for updating rather than overwriting the one big graph in the current working directory (assumed to be the git repo root directory), we need to continue to store package-or directory-specific graphs in the directory (path) passed to `init`.

## How?

Revert changes in https://github.com/nuanced-dev/nuanced/pull/84

## Testing

- Tests pass
- QA with local copy of django repo

```bash
% pwd
/Users/laila/Source/django
% nuanced init .
Initializing /Users/laila/Source/django
Operation timed out
% nuanced init django
Initializing /Users/laila/Source/django/django
Done
% nuanced init tests/servers
Initializing /Users/laila/Source/django/tests/servers
Done
% nuanced enrich tests/servers/tests.py test_check_model_instance_from_subview | head -n 2
{
  "tests.servers.tests.LiveServerThreadedTests.test_check_model_instance_from_subview": {
% nuanced enrich django/core/servers/basehttp.py is_broken_pipe_error
{
  "django.core.servers.basehttp.is_broken_pipe_error": {
    "filepath": "/Users/laila/Source/django/django/core/servers/basehttp.py",
    "callees": [
      "sys.exc_info"
    ],
    "lineno": 56,
    "end_lineno": 63
  }
}
```

Without the changes in this PR, attempting to run `enrich` outputs this error:

```bash
Multiple Nuanced Graphs found in /Users/laila/Source/django: django/.nuanced/nuanced-graph.json, tests/servers/.nuanced/nuanced-graph.json
```

ref: https://github.com/nuanced-dev/nuanced-operations/issues/239, https://github.com/nuanced-dev/nuanced/issues/72, https://github.com/nuanced-dev/nuanced/issues/82
