### PR TITLE
enrich CLI command looks for graph in cwd first

### DIFF
--- a/src/nuanced/cli.py
+++ b/src/nuanced/cli.py
@@ -74,10 +74,10 @@ def cli(
         raise typer.Exit()
 
 def _find_code_graph(file_path: str) -> CodeGraphResult:
-    file_directory, _file_name = os.path.split(file_path)
-    code_graph_result = CodeGraph.load(directory=file_directory)
+    code_graph_result = CodeGraph.load(directory=os.getcwd())
 
     if len(code_graph_result.errors) > 0:
+        file_directory, _file_name = os.path.split(file_path)
         top_directory = file_directory.split("/")[0]
 
         for root, dirs, _files in os.walk(top_directory, topdown=False):

--- a/tests/nuanced/cli_test.py
+++ b/tests/nuanced/cli_test.py
@@ -15,7 +15,8 @@ def test_version_displays_installed_version():
 
     assert result.stdout == f"nuanced {__version__}\n"
 
-def test_enrich_finds_relevant_graph_in_file_dir(mocker):
+def test_enrich_finds_relevant_graph_in_cwd(mocker):
+    cwd_abspath = os.getcwd()
     graph = { "foo.bar": { "filepath": os.path.abspath("foo.py"), "callees": [] } }
     code_graph = CodeGraph(graph=graph)
     mocker.patch(
@@ -26,11 +27,11 @@ def test_enrich_finds_relevant_graph_in_file_dir(mocker):
 
     runner.invoke(app, ["enrich", "foo.py", "bar"])
 
-    load_spy.assert_called_with(directory="")
+    load_spy.assert_called_with(directory=cwd_abspath)
 
 def test_enrich_finds_relevant_graph_in_file_path_parent_dir(mocker):
     file_path = "foo/bar/baz.py"
-    file_dir, _ = os.path.split(file_path)
+    cwd_abspath = os.getcwd()
     top_dir = "foo"
     top_dir_contents = (top_dir, [CodeGraph.NUANCED_DIRNAME, "bar"], ["__init__.py"])
     stub_graph = {}
@@ -39,9 +40,9 @@ def test_enrich_finds_relevant_graph_in_file_path_parent_dir(mocker):
     mocker.patch("os.walk", lambda directory: [top_dir_contents])
     mocker.patch(
         "nuanced.cli.CodeGraph.load",
-        lambda directory: result_with_errors if directory == file_dir else valid_result
+        lambda directory: result_with_errors if directory == cwd_abspath else valid_result
     )
-    expected_calls = [mocker.call(directory=file_dir)]
+    expected_calls = [mocker.call(directory=cwd_abspath)]
     load_spy = mocker.spy(CodeGraph, "load")
 
     runner.invoke(app, ["enrich", file_path, "hello_world"])


### PR DESCRIPTION
## Why?

This was an oversight! When reinstating `_find_code_graph` in https://github.com/nuanced-dev/nuanced/pull/89 I forgot that it would need to be updated to check the current working directory for a graph.

## How?

Update `_find_code_graph` in src/nuanced/cli.py to check the current working directory for a graph file before traversing the directories in the input file path.