### PR TITLE
Add GitHub Actions workflow for running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.13"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: "latest"
+
+    - name: Set up Python ${{ matrix.python-version }}
+      run: uv python install ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: uv sync --dev
+
+    - name: Run tests
+      run: uv run pytest tests/ -v

--- a/tests/nuanced/code_graph_test.py
+++ b/tests/nuanced/code_graph_test.py
@@ -74,11 +74,13 @@ def test_init_with_invalid_path_returns_errors(mocker) -> None:
 
 def test_init_with_no_eligible_files_returns_errors(mocker) -> None:
     no_eligible_files_path = "tests/package_fixtures/ineligible"
+    os.mkdir(no_eligible_files_path)
 
     code_graph_result = CodeGraph.init(no_eligible_files_path)
 
     assert len(code_graph_result.errors) == 1
     assert str(code_graph_result.errors[0]) == f"No eligible files found in {os.path.abspath(no_eligible_files_path)}"
+    os.rmdir(no_eligible_files_path)
 
 def test_init_with_valid_path_persists_code_graph(mocker) -> None:
     mocker.patch("os.makedirs", lambda _dirname, exist_ok=True: None)


### PR DESCRIPTION
## Why?

It can be hard to remember to run tests locally before merging. Running tests in a CI pipeline will give everyone more confidence in the code we're shipping.

## How?

- I asked Aider to generate a GitHub Actions workflow for running pytest tests on CI using uv
- Then I modified the file it generated to only use Python 3.13 instead of Python 3.10, 3.11 and 3.12
- I also updated a test that requires the presence of an empty directory to create and tear down the empty directory. This is necessary because git does not track empty directories.

## Testing

- Example failed run: https://github.com/nuanced-dev/nuanced/actions/runs/15911654804/job/44880259316
- Example successful run: https://github.com/nuanced-dev/nuanced/actions/runs/15911670367/job/44880312446